### PR TITLE
feat: add sample-project consumer and playwright e2e suite

### DIFF
--- a/.claude/agent-memory/django-rest-framework-specialist/MEMORY.md
+++ b/.claude/agent-memory/django-rest-framework-specialist/MEMORY.md
@@ -7,3 +7,4 @@
 - [Filter-queryset scope on writes — resolved at 0ae844fa](divergence_filter_queryset_scope.md) — historical: cross-tenant mutation gap was closed by routing every row-resolving write through FilterQuery(GetQuerySet())
 - [Divergence: IQueryable threaded through serializer surface](divergence_iqueryable_serializer_surface.md) — DRF serializer is queryset-naive; recommend DRF-shaped (instance for single-row, queryset only for bulk-execute)
 - [DRF generics.py get_object / filter_queryset anchors](drf_generics_get_object_anchors.md) — load-then-write flow, check_object_permissions, get_serializer_context, get_success_headers
+- [DRF disable-action anchors](drf_disable_action_anchors.md) — composition (ReadOnlyModelViewSet/GenericViewSet+mixins) is canonical; routers.py:226-234 + 278-280 drive 404-vs-405; destroy is not special-cased

--- a/.claude/agent-memory/django-rest-framework-specialist/drf_disable_action_anchors.md
+++ b/.claude/agent-memory/django-rest-framework-specialist/drf_disable_action_anchors.md
@@ -1,0 +1,45 @@
+---
+name: drf-disable-action-anchors
+description: DRF 3.17.1 pinned anchors for disable-an-action mechanisms (composition, http_method_names, router filtering, 405 vs 404 path)
+metadata:
+  type: reference
+---
+
+All paths under `encode/django-rest-framework@3.17.1`.
+
+## Composition mechanism (canonical, doc-recommended)
+
+- `rest_framework/viewsets.py:212-219` — `ReadOnlyModelViewSet(RetrieveModelMixin, ListModelMixin, GenericViewSet)`. This IS the canonical example of "ModelViewSet minus create/update/destroy".
+- `rest_framework/viewsets.py:221-231` — `ModelViewSet(CreateModelMixin, RetrieveModelMixin, UpdateModelMixin, DestroyModelMixin, ListModelMixin, GenericViewSet)`. The full set.
+- `rest_framework/viewsets.py:198-202` — `GenericViewSet(ViewSetMixin, generics.GenericAPIView)`. "No actions by default" — base for custom composition.
+- `docs/api-guide/viewsets.md` section "Custom ViewSet base classes" — explicitly documents `CreateListRetrieveViewSet(CreateModelMixin, ListModelMixin, RetrieveModelMixin, GenericViewSet)` as the idiom. **This is the official DRF recommendation, not `http_method_names`.**
+
+## Router-driven URL filtering (composition produces 404, not 405)
+
+- `rest_framework/routers.py:226-234` — `SimpleRouter.get_method_map(viewset, method_map)`: for each `method -> action` in the route's mapping, includes only those where `hasattr(viewset, action)`.
+- `rest_framework/routers.py:266-302` — `SimpleRouter.get_urls`. Key lines 278-280: `mapping = self.get_method_map(viewset, route.mapping); if not mapping: continue`. If a route's entire mapping has no actions on the viewset, the URL pattern is NOT registered at all.
+
+Resulting status code semantics:
+- **Route fully unregistered** (e.g., a viewset with only `list`/`retrieve` — there's no detail mapping involving `update`/`partial_update`/`destroy` because those don't exist, but `retrieve` exists, so the detail URL IS registered): the verbs present on the viewset go to handlers; the verbs absent from the route's mapping get **405**, because the URL is registered.
+- **Per-route, mixed**: detail URL has `{'get':'retrieve','put':'update','patch':'partial_update','delete':'destroy'}`. If `destroy` is missing from the viewset, `get_method_map` drops `'delete'` from the mapping. The URL is still registered (because `retrieve` exists). Wrong verb -> goes through Django's `View.dispatch` which checks `request.method.lower() in self.http_method_names` (always True for standard verbs) but then `getattr(self, 'delete', self.http_method_not_allowed)` returns `http_method_not_allowed` since the viewset doesn't have a `delete` attribute bound. **Result: 405.**
+- **Whole URL skipped**: only happens if the entire route's mapping is empty (e.g., omitting `list` AND `create` skips the list URL entirely). Then **404**.
+
+## http_method_names mechanism (less common, but valid)
+
+- `rest_framework/views.py:484-490` (in `APIView.dispatch`): `if request.method.lower() in self.http_method_names: handler = getattr(self, request.method.lower(), self.http_method_not_allowed) else: handler = self.http_method_not_allowed`. Both branches funnel to `http_method_not_allowed`.
+- `rest_framework/views.py:165-170` — `http_method_not_allowed` raises `exceptions.MethodNotAllowed(request.method)`.
+- `rest_framework/exceptions.py:191-200` — `MethodNotAllowed(APIException)`, `status_code = HTTP_405_METHOD_NOT_ALLOWED`.
+
+Note: `http_method_names` is a `django.views.generic.View` attribute inherited by `APIView`. Overriding it on a viewset works but is documented less prominently than composition.
+
+## Destroy is NOT special-cased in DRF
+
+- `rest_framework/mixins.py:79-89` — `DestroyModelMixin` is structurally identical to `UpdateModelMixin` and `CreateModelMixin`. Same `perform_destroy` hook (line 88-89, body `instance.delete()`). No permission/decorator/check that treats DELETE as more dangerous.
+- `ModelViewSet`'s mixin chain (`viewsets.py:221`) lists `DestroyModelMixin` alongside the others — equal rank.
+- The disable-by-composition idiom (`ReadOnlyModelViewSet`) drops `create`, `update`, `destroy` together as "writes". DRF's design treats the read/write split as the load-bearing line, not destroy-vs-update.
+
+## What DRF does NOT have at 3.17.1
+
+- No `get_view_methods` (that's a `main`-branch / post-3.17.1 addition introduced for OpenAPI generation; not relevant here).
+- No `Allow*` flags or boolean per-action toggles. Composition + `http_method_names` are the only canonical mechanisms.
+- No `[NonAction]`-like attribute. Python's "delete the method from the class" is composition, not an attribute marker — the closest equivalent is "don't mix in the mixin in the first place".

--- a/.claude/rules/action-options.md
+++ b/.claude/rules/action-options.md
@@ -1,0 +1,39 @@
+---
+paths: "src/NDjango.RestFramework/Base/ActionOptions.cs"
+---
+
+# ActionOptions
+
+Per-controller toggles that gate HTTP actions on `BaseController`. Library-specific idiom — DRF has no equivalent (DRF disables actions via mixin composition / `http_method_names`); the divergence is intentional and documented in `README.md`.
+
+## Naming
+
+- Name each flag `Allow{ActionName}` matching the controller action exactly: `AllowPatch` ↔ `Patch`, `AllowPut` ↔ `Put`, `AllowDelete` ↔ `Delete`, `AllowBulkDelete` ↔ `DeleteMany`.
+- One flag per controller action. Do not group multiple verbs behind a single flag.
+
+## Defaults
+
+- Default `true` (opt-out) when the action's persistence path runs through the documented hook seams (`ValidateDestroyAsync`, `Perform*Async`, EF interceptors, audit, soft-delete). `AllowPatch`, `AllowPut`, `AllowDelete` follow this rule.
+- Default `false` (opt-in) when the action silently *bypasses* those seams. `AllowBulkDelete` is the canonical opt-in: `DestroyManyAsync` runs a single `ExecuteDeleteAsync` and skips per-row validation, interceptors, and hooks.
+- Document the bypass list in xmldoc whenever a flag defaults `false`. The flag is a discoverable warning, not just a route toggle.
+
+## Wire-up convention
+
+- Enforce each flag as the **first statement** of its action in `BaseController`:
+  ```csharp
+  if (!_actionOptions.AllowX) return StatusCode(StatusCodes.Status405MethodNotAllowed);
+  ```
+- Return `405 Method Not Allowed` inline. Do not migrate to `[NonAction]` — `[NonAction]` removes the action from the MVC route table and OpenAPI surface (consumer-invisible) and resolves disabled hits to `404`. The inline `405` keeps the endpoint discoverable in OpenAPI / `OPTIONS` as "documented endpoint, off by default."
+- When adding, renaming, or removing a flag: update `README.md` "Disabling endpoints" table, the xmldoc on the corresponding `BaseController` action, and the `BaseController.{Action}` tests that assert `405` when the flag is `false`.
+
+## Scope
+
+- Only mutating actions (`Patch`, `Put`, `Delete`, `DeleteMany`) are flag-gated. Read actions (`GetSingle`, `ListPaged`) and `Post` are intentionally not flag-gated — the absence is by design, not oversight.
+- Do not add `AllowGetSingle` / `AllowList` / `AllowPost` reflexively for symmetry. Adding them requires an explicit use case beyond "consistency."
+- `ActionOptions` is for **HTTP action gating only**. Do not push unrelated controller knobs (pagination strategy, validation modes, serializer wiring) onto this class.
+
+## Forbidden
+
+- Do not replace `Allow*` flags with `[NonAction]` overrides. The mechanisms are not semantically equivalent (route presence, OpenAPI surface, `OPTIONS` discovery, status code on disabled hits all differ).
+- Do not return `404` from a disabled action. The contract is `405 Method Not Allowed`.
+- Do not use `ActionOptions` as a feature-flag bag. One job: HTTP action gating.

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,93 @@
+name: Playwright E2E
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+    paths:
+      - 'src/**'
+      - 'sample-project/**'
+      - 'playwright/**'
+      - '.github/workflows/playwright.yml'
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    name: Playwright tests (chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: playwright/package-lock.json
+
+      - name: Start SQL Server
+        run: docker compose up --detach --wait --wait-timeout 180 db
+
+      - name: Build sample-project
+        run: dotnet build sample-project/src/SampleProject.csproj --configuration Debug
+
+      - name: Install Playwright dependencies
+        working-directory: playwright
+        run: |
+          npm ci --ignore-scripts
+          npm run install-browsers -- chromium
+
+      - name: Start sample-project (:8000) in background
+        working-directory: sample-project/src
+        run: |
+          nohup dotnet run --no-build --no-launch-profile > /tmp/sample-project.log 2>&1 &
+          echo $! > /tmp/sample-project.pid
+
+      - name: Wait for sample-project to be ready
+        run: |
+          for i in $(seq 1 90); do
+            if curl --fail --silent http://localhost:8000/swagger/v1/swagger.json > /dev/null; then
+              echo "sample-project (:8000) is up"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "sample-project failed to start within 180s"
+          echo "----- /tmp/sample-project.log -----"
+          tail -200 /tmp/sample-project.log || true
+          exit 1
+
+      - name: Run Playwright tests
+        working-directory: playwright
+        env:
+          CI: 'true'
+        run: npm test -- --project=chromium
+
+      - name: Stop sample-project
+        if: always()
+        run: |
+          if [ -f /tmp/sample-project.pid ]; then
+            kill "$(cat /tmp/sample-project.pid)" || true
+          fi
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright/playwright-report
+          retention-days: 14
+
+      - name: Upload sample-project log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sample-project-log
+          path: /tmp/sample-project.log
+          retention-days: 14

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Check if the project is well formatted
         run: |
           ./scripts/start-check-formatting.sh
-      - name: Install dotnet-sonarscanner
-        run: |
-          dotnet tool install --global dotnet-sonarscanner
       - name: Build the project, run all tests, and publish the test results
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
-ARG DOTNET_VERSION=8.0
+ARG DOTNET_VERSION=10.0
 
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_VERSION
+
+# Project targets net8.0 or net9.0 - install their runtimes so dotnet test/run works
+COPY --from=mcr.microsoft.com/dotnet/runtime:8.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
+COPY --from=mcr.microsoft.com/dotnet/aspnet:8.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
+COPY --from=mcr.microsoft.com/dotnet/runtime:9.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
+COPY --from=mcr.microsoft.com/dotnet/aspnet:9.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Only `Name` is updated; `CreatedAt`, `UpdatedAt`, etc. remain untouched.
 
 ### Disabling endpoints
 
-Use `ActionOptions` to disable PUT, PATCH, or the bulk-delete endpoint:
+Use `ActionOptions` to disable PUT, PATCH, DELETE, or the bulk-delete endpoint:
 
 ```csharp
 public PersonsController(...)
@@ -350,6 +350,7 @@ public PersonsController(...)
 |---|---|---|
 | `AllowPatch` | `true` | `PATCH /{id}` |
 | `AllowPut` | `true` | `PUT /{id}` |
+| `AllowDelete` | `true` | `DELETE /{id}` |
 | `AllowBulkDelete` | `false` | `DELETE ?ids=` (the bulk-delete endpoint, opt-in) |
 
 Disabled endpoints return `405 Method Not Allowed`. **Bulk delete is opt-in** — set `AllowBulkDelete = true` to expose `DELETE ?ids=`. The opt-in default is intentional: the bulk path runs a single `ExecuteDeleteAsync` SQL statement and silently bypasses `ValidateDestroyAsync`, any override of `Serializer.DestroyAsync(instance, ct)`, EF Core `SaveChanges` interceptors, audit-on-delete hooks, and soft-delete logic. Enable it only when those seams either don't exist on this resource or carry rules the bulk path is allowed to skip.

--- a/playwright/.gitignore
+++ b/playwright/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+test-results/
+playwright-report/
+playwright/.cache/
+blob-report/
+*.log
+.env
+.env.local

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -1,0 +1,44 @@
+# Playwright tests
+
+End-to-end CRUD + OpenAPI contract tests for `NDjango.RestFramework`, driven through `sample-project/`.
+
+## Prerequisites
+
+- Node.js 20+
+- .NET 8 SDK
+- Docker (the SQL Server `db` service from `docker-compose.yml`)
+
+## Local
+
+```bash
+# 1. Start SQL Server (port 1433)
+docker compose up -d db
+
+# 2. Install playwright + browsers (once)
+cd playwright
+npm install
+npm run install-browsers
+
+# 3. Run tests — webServer block in playwright.config.ts auto-starts sample-project on :8000
+npm test
+```
+
+`webServer.reuseExistingServer = true` means you can leave `sample-project` running between test runs.
+
+## Layout
+
+```
+playwright/
+├── helpers/data.ts          # tiny unique() helper to dodge unique-index collisions
+├── tests/openapi.spec.ts    # OpenAPI document contract assertions
+├── tests/crud.spec.ts       # CRUD per resource (Categories, Restaurants, ...)
+├── playwright.config.ts     # chromium project, sequential, baseURL=http://localhost:8000
+├── tsconfig.json
+└── package.json
+```
+
+Sequential by design (`fullyParallel: false`, `workers: 1`) — the sample shares one SQL Server database, and a couple of tests rely on exact counts on the collection endpoints. Relax once we want per-test isolation.
+
+## CI
+
+`.github/workflows/playwright.yml` brings up `db`, builds + starts `sample-project`, then runs `npx playwright test`. The HTML report is uploaded on every run; the sample's stdout log only on failure.

--- a/playwright/helpers/data.ts
+++ b/playwright/helpers/data.ts
@@ -1,0 +1,9 @@
+/**
+ * Returns a value-prefixed unique string so concurrent or repeated test runs don't
+ * collide on the sample's unique indexes (Category.Name, Ingredient.Name, etc.).
+ */
+export function unique(prefix: string): string {
+  const stamp = Date.now().toString(36);
+  const noise = Math.random().toString(36).slice(2, 8);
+  return `${prefix}-${stamp}-${noise}`;
+}

--- a/playwright/package-lock.json
+++ b/playwright/package-lock.json
@@ -1,0 +1,114 @@
+{
+  "name": "ndjango-restframework-playwright",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ndjango-restframework-playwright",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.59.1",
+        "@types/node": "^22.10.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ndjango-restframework-playwright",
+  "version": "1.0.0",
+  "private": true,
+  "description": "End-to-end CRUD + OpenAPI contract tests for NDjango.RestFramework, driven through sample-project.",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "test:debug": "playwright test --debug",
+    "test:report": "playwright show-report",
+    "install-browsers": "playwright install --with-deps"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1",
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const BASE_URL = process.env.SAMPLE_PROJECT_URL ?? 'http://localhost:8000';
+
+export default defineConfig({
+  testDir: './tests',
+  // Sequential by default: the sample shares one database, and tests rely on
+  // exact counts on collection endpoints. Easy to relax once tests are isolated.
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  reporter: process.env.CI
+    ? [['html', { open: 'never' }], ['github']]
+    : [['html', { open: 'on-failure' }], ['list']],
+  use: {
+    baseURL: BASE_URL,
+    extraHTTPHeaders: { Accept: 'application/json' },
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  // Locally: spawn the sample under test and reuse it across reruns.
+  // In CI: the workflow starts the sample explicitly, so don't double-start.
+  webServer: process.env.CI
+    ? undefined
+    : {
+        command: 'dotnet run --no-launch-profile --project ../sample-project/src/SampleProject.csproj',
+        url: `${BASE_URL}/swagger/v1/swagger.json`,
+        reuseExistingServer: true,
+        timeout: 180_000,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+});

--- a/playwright/tests/audit-logs.spec.ts
+++ b/playwright/tests/audit-logs.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+import { unique } from '../helpers/data';
+
+/**
+ * AuditLogs is wired as an append-only resource via ActionOptions:
+ *   AllowPatch     = false
+ *   AllowPut       = false
+ *   AllowDelete    = false
+ *   AllowBulkDelete = false
+ *
+ * GET (list + item) and POST are the only allowed verbs. Every other call returns
+ * 405 Method Not Allowed inline — the endpoint stays listed in OpenAPI (asserted in
+ * openapi.spec.ts) but the runtime guard short-circuits before the action body.
+ */
+test.describe('AuditLogs — HTTP method allowlist', () => {
+  let id = 0;
+
+  test.beforeAll(async ({ request }) => {
+    const response = await request.post('/api/AuditLogs', {
+      data: { action: 'CREATE', entityName: 'Tag', detail: unique('seed') },
+    });
+    expect(response.status()).toBe(201);
+    id = (await response.json()).id;
+  });
+
+  test('GET list and GET single succeed', async ({ request }) => {
+    const list = await request.get('/api/AuditLogs');
+    expect(list.status()).toBe(200);
+    expect((await list.json()).count).toBeGreaterThanOrEqual(1);
+
+    const single = await request.get(`/api/AuditLogs/${id}`);
+    expect(single.status()).toBe(200);
+  });
+
+  test('POST succeeds (append-only is still write-once-allowed)', async ({ request }) => {
+    const response = await request.post('/api/AuditLogs', {
+      data: { action: 'UPDATE', entityName: 'Restaurant', detail: 'ok' },
+    });
+    expect(response.status()).toBe(201);
+  });
+
+  test('PATCH returns 405', async ({ request }) => {
+    const response = await request.patch(`/api/AuditLogs/${id}`, { data: { detail: 'edited' } });
+    expect(response.status()).toBe(405);
+  });
+
+  test('PUT returns 405', async ({ request }) => {
+    const response = await request.put(`/api/AuditLogs/${id}`, {
+      data: { action: 'DELETE', entityName: 'X', detail: null },
+    });
+    expect(response.status()).toBe(405);
+  });
+
+  test('single DELETE returns 405', async ({ request }) => {
+    const response = await request.delete(`/api/AuditLogs/${id}`);
+    expect(response.status()).toBe(405);
+  });
+
+  test('bulk DELETE returns 405', async ({ request }) => {
+    const response = await request.delete(`/api/AuditLogs?ids=${id}`);
+    expect(response.status()).toBe(405);
+  });
+});

--- a/playwright/tests/crud.spec.ts
+++ b/playwright/tests/crud.spec.ts
@@ -1,0 +1,261 @@
+import { APIRequestContext, expect, test } from '@playwright/test';
+import { unique } from '../helpers/data';
+
+/**
+ * End-to-end CRUD coverage per controller in sample-project/Commands/ApiCommand.cs.
+ *
+ * Each describe block exercises the same six-verb surface (GET list, POST, GET single,
+ * PATCH, PUT, DELETE) so a regression in the library's BaseController action shape will
+ * fail the matching resource. Resources with FK chains (RestaurantProfile, MenuItem)
+ * create their parent inline rather than relying on shared fixtures.
+ *
+ * Extra assertions per resource cover the library-specific knobs:
+ *   - Restaurants: AllowBulkDelete = true → DELETE /api/Restaurants?ids=... → 204
+ *   - MenuItems:   AllowDelete     = false → DELETE /api/MenuItems/{id}    → 405
+ */
+
+async function createRestaurant(request: APIRequestContext): Promise<number> {
+  const response = await request.post('/api/Restaurants', {
+    data: {
+      name: unique('Restaurant'),
+      address: '1 Test St',
+      phone: '555-0000',
+    },
+  });
+  expect(response.status()).toBe(201);
+  return (await response.json()).id;
+}
+
+test.describe('Categories CRUD', () => {
+  test('create → list → read → patch → put → delete', async ({ request }) => {
+    const name = unique('pizza');
+    const create = await request.post('/api/Categories', {
+      data: { name, description: 'woodfired' },
+    });
+    expect(create.status()).toBe(201);
+    const created = await create.json();
+    expect(created.id).toBeGreaterThan(0);
+    expect(created.name).toBe(name);
+    expect(created.createdAt).toBeTruthy();
+
+    const list = await request.get('/api/Categories');
+    expect(list.status()).toBe(200);
+    const page = await list.json();
+    expect(page.count).toBeGreaterThanOrEqual(1);
+    expect(Array.isArray(page.results)).toBe(true);
+
+    const read = await request.get(`/api/Categories/${created.id}`);
+    expect(read.status()).toBe(200);
+    expect((await read.json()).name).toBe(name);
+
+    const patch = await request.patch(`/api/Categories/${created.id}`, {
+      data: { description: 'patched' },
+    });
+    expect(patch.status()).toBe(200);
+    expect((await patch.json()).description).toBe('patched');
+
+    const put = await request.put(`/api/Categories/${created.id}`, {
+      data: { name: unique('renamed'), description: 'put' },
+    });
+    expect(put.status()).toBe(200);
+    expect((await put.json()).description).toBe('put');
+
+    const del = await request.delete(`/api/Categories/${created.id}`);
+    expect(del.status()).toBe(204);
+
+    const readGone = await request.get(`/api/Categories/${created.id}`);
+    expect(readGone.status()).toBe(404);
+  });
+});
+
+test.describe('Restaurants CRUD', () => {
+  test('create → list → read → patch → put → delete', async ({ request }) => {
+    const name = unique('Restaurant');
+    const create = await request.post('/api/Restaurants', {
+      data: { name, address: '742 Evergreen Terrace', phone: '555-1234' },
+    });
+    expect(create.status()).toBe(201);
+    const created = await create.json();
+
+    const read = await request.get(`/api/Restaurants/${created.id}`);
+    expect(read.status()).toBe(200);
+
+    const patch = await request.patch(`/api/Restaurants/${created.id}`, {
+      data: { phone: '555-9999' },
+    });
+    expect(patch.status()).toBe(200);
+    expect((await patch.json()).phone).toBe('555-9999');
+
+    const put = await request.put(`/api/Restaurants/${created.id}`, {
+      data: { name: unique('Reborn'), address: 'new', phone: '000-0000' },
+    });
+    expect(put.status()).toBe(200);
+
+    const del = await request.delete(`/api/Restaurants/${created.id}`);
+    expect(del.status()).toBe(204);
+  });
+
+  test('bulk delete (AllowBulkDelete=true) removes ids in a single shot', async ({ request }) => {
+    const a = await createRestaurant(request);
+    const b = await createRestaurant(request);
+
+    const bulk = await request.delete(`/api/Restaurants?ids=${a}&ids=${b}`);
+    expect(bulk.status()).toBe(204);
+
+    const gone = await request.get(`/api/Restaurants/${a}`);
+    expect(gone.status()).toBe(404);
+  });
+});
+
+test.describe('RestaurantProfiles CRUD', () => {
+  test('create → list → read → patch → put → delete (with parent FK)', async ({ request }) => {
+    const restaurantId = await createRestaurant(request);
+
+    const create = await request.post('/api/RestaurantProfiles', {
+      data: {
+        restaurantId,
+        website: 'https://example.com',
+        openingHours: '9-22',
+        capacity: 40,
+      },
+    });
+    expect(create.status()).toBe(201);
+    const created = await create.json();
+
+    const patch = await request.patch(`/api/RestaurantProfiles/${created.id}`, {
+      data: { capacity: 80 },
+    });
+    expect(patch.status()).toBe(200);
+    expect((await patch.json()).capacity).toBe(80);
+
+    const put = await request.put(`/api/RestaurantProfiles/${created.id}`, {
+      data: { restaurantId, website: '', openingHours: '24/7', capacity: 100 },
+    });
+    expect(put.status()).toBe(200);
+
+    const del = await request.delete(`/api/RestaurantProfiles/${created.id}`);
+    expect(del.status()).toBe(204);
+  });
+});
+
+test.describe('Ingredients CRUD', () => {
+  test('create → list → read → patch → put → delete', async ({ request }) => {
+    const name = unique('tomato');
+    const create = await request.post('/api/Ingredients', {
+      data: { name, isAllergen: false },
+    });
+    expect(create.status()).toBe(201);
+    const created = await create.json();
+
+    const patch = await request.patch(`/api/Ingredients/${created.id}`, {
+      data: { isAllergen: true },
+    });
+    expect(patch.status()).toBe(200);
+    expect((await patch.json()).isAllergen).toBe(true);
+
+    const put = await request.put(`/api/Ingredients/${created.id}`, {
+      data: { name: unique('renamed'), isAllergen: false },
+    });
+    expect(put.status()).toBe(200);
+
+    const del = await request.delete(`/api/Ingredients/${created.id}`);
+    expect(del.status()).toBe(204);
+  });
+});
+
+test.describe('MenuItems CRUD', () => {
+  test('create → list → read → patch → put (single DELETE disabled)', async ({ request }) => {
+    const restaurantId = await createRestaurant(request);
+
+    const create = await request.post('/api/MenuItems', {
+      data: {
+        restaurantId,
+        name: unique('Margherita'),
+        description: 'classic',
+        price: 19.9,
+        isAvailable: true,
+      },
+    });
+    expect(create.status()).toBe(201);
+    const created = await create.json();
+
+    const patch = await request.patch(`/api/MenuItems/${created.id}`, {
+      data: { isAvailable: false },
+    });
+    expect(patch.status()).toBe(200);
+    expect((await patch.json()).isAvailable).toBe(false);
+
+    const put = await request.put(`/api/MenuItems/${created.id}`, {
+      data: {
+        restaurantId,
+        name: unique('Renamed'),
+        description: 'put',
+        price: 29.9,
+        isAvailable: true,
+      },
+    });
+    expect(put.status()).toBe(200);
+  });
+
+  test('DELETE returns 405 when AllowDelete=false', async ({ request }) => {
+    const restaurantId = await createRestaurant(request);
+    const create = await request.post('/api/MenuItems', {
+      data: {
+        restaurantId,
+        name: unique('DoomedToStay'),
+        description: '',
+        price: 1,
+        isAvailable: true,
+      },
+    });
+    const created = await create.json();
+
+    const del = await request.delete(`/api/MenuItems/${created.id}`);
+    expect(del.status()).toBe(405);
+
+    // Row is still there — guard short-circuited before persistence.
+    const stillThere = await request.get(`/api/MenuItems/${created.id}`);
+    expect(stillThere.status()).toBe(200);
+  });
+});
+
+test.describe('Gifts CRUD', () => {
+  test('round-trips the wide primitive-type surface', async ({ request }) => {
+    const payload = {
+      name: unique('gift'),
+      isWrapped: true,
+      trackingCode: '00000000-0000-0000-0000-000000000001',
+      price: 12.34,
+      barcode: 9_876_543_210,
+      weight: 1.25,
+      rating: 4.5,
+      quantityInStock: 7,
+      minAge: 3,
+      shippedAt: '2026-05-12T10:00:00+00:00',
+      preparationTime: '00:30:00',
+      expirationDate: '2027-01-01',
+      availableFrom: '08:00:00',
+      description: 'sample',
+      notes: 'wide type surface',
+    };
+
+    const create = await request.post('/api/Gifts', { data: payload });
+    expect(create.status()).toBe(201);
+    const created = await create.json();
+    expect(created.id).toBeGreaterThan(0);
+    expect(created.isWrapped).toBe(true);
+    expect(created.quantityInStock).toBe(7);
+    expect(created.minAge).toBe(3);
+
+    const patch = await request.patch(`/api/Gifts/${created.id}`, {
+      data: { rating: 5.0, quantityInStock: 99 },
+    });
+    expect(patch.status()).toBe(200);
+    const patched = await patch.json();
+    expect(patched.rating).toBeCloseTo(5.0);
+    expect(patched.quantityInStock).toBe(99);
+
+    const del = await request.delete(`/api/Gifts/${created.id}`);
+    expect(del.status()).toBe(204);
+  });
+});

--- a/playwright/tests/list-features.spec.ts
+++ b/playwright/tests/list-features.spec.ts
@@ -1,0 +1,201 @@
+import { APIRequestContext, expect, test } from '@playwright/test';
+import { unique } from '../helpers/data';
+
+/**
+ * Exercises the library's "free" list-endpoint surface — pagination, sorting, and the three
+ * built-in filters (QueryStringFilter, QueryStringSearchFilter, QueryStringIdRangeFilter) —
+ * plus the custom <see cref="OnlyAvailableMenuItemsFilter"/> wired on MenuItemsController.
+ *
+ * Tests scope themselves with the id-range filter (?ids=) so the assertions stay
+ * deterministic regardless of what other specs left in the database.
+ */
+
+async function seedTags(
+  request: APIRequestContext,
+  prefix: string,
+  count: number,
+): Promise<number[]> {
+  const ids: number[] = [];
+  for (let i = 0; i < count; i++) {
+    const idx = String(i + 1).padStart(3, '0');
+    const response = await request.post('/api/Tags', {
+      data: { name: `${prefix}-${idx}`, slug: `${prefix}-${idx}-slug` },
+    });
+    expect(response.status()).toBe(201);
+    ids.push((await response.json()).id);
+  }
+  return ids;
+}
+
+function idsParam(ids: number[]): string {
+  return ids.map((id) => `ids=${id}`).join('&');
+}
+
+test.describe('Pagination — PageNumberPagination envelope', () => {
+  test('page=1 + page_size=5 over 12 ids: count, next set, previous null', async ({ request }) => {
+    const prefix = unique('page');
+    const ids = await seedTags(request, prefix, 12);
+
+    const response = await request.get(`/api/Tags?${idsParam(ids)}&page=1&page_size=5`);
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body.count).toBe(12);
+    expect(body.results).toHaveLength(5);
+    expect(body.previous).toBeFalsy();
+    expect(body.next).toContain('page=2');
+  });
+
+  test('page=3 + page_size=5: tail page returns partial results, next null', async ({ request }) => {
+    const prefix = unique('page');
+    const ids = await seedTags(request, prefix, 12);
+
+    const response = await request.get(`/api/Tags?${idsParam(ids)}&page=3&page_size=5`);
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body.count).toBe(12);
+    expect(body.results).toHaveLength(2);
+    expect(body.next).toBeFalsy();
+    expect(body.previous).toContain('page=2');
+  });
+});
+
+test.describe('Sorting — ?sort= ascending, ?sortDesc= descending', () => {
+  test('?sort=Name returns rows in lexicographic ascending order', async ({ request }) => {
+    const prefix = unique('sort');
+    // Deliberately seed out of order so the sort proves itself.
+    const seeds: { name: string; slug: string }[] = [
+      { name: `${prefix}-charlie`, slug: `${prefix}-c-s` },
+      { name: `${prefix}-alpha`,   slug: `${prefix}-a-s` },
+      { name: `${prefix}-bravo`,   slug: `${prefix}-b-s` },
+    ];
+    const ids: number[] = [];
+    for (const s of seeds) {
+      const r = await request.post('/api/Tags', { data: s });
+      expect(r.status()).toBe(201);
+      ids.push((await r.json()).id);
+    }
+
+    const response = await request.get(`/api/Tags?${idsParam(ids)}&sort=Name`);
+    expect(response.status()).toBe(200);
+    const names: string[] = (await response.json()).results.map((r: any) => r.name);
+    expect(names).toEqual([`${prefix}-alpha`, `${prefix}-bravo`, `${prefix}-charlie`]);
+  });
+
+  test('?sortDesc=Name reverses the order', async ({ request }) => {
+    const prefix = unique('sortdesc');
+    const seeds = [
+      { name: `${prefix}-alpha`,   slug: `${prefix}-a-s` },
+      { name: `${prefix}-bravo`,   slug: `${prefix}-b-s` },
+      { name: `${prefix}-charlie`, slug: `${prefix}-c-s` },
+    ];
+    const ids: number[] = [];
+    for (const s of seeds) {
+      const r = await request.post('/api/Tags', { data: s });
+      ids.push((await r.json()).id);
+    }
+
+    const response = await request.get(`/api/Tags?${idsParam(ids)}&sortDesc=Name`);
+    expect(response.status()).toBe(200);
+    const names: string[] = (await response.json()).results.map((r: any) => r.name);
+    expect(names).toEqual([`${prefix}-charlie`, `${prefix}-bravo`, `${prefix}-alpha`]);
+  });
+});
+
+test.describe('Built-in filters', () => {
+  test('QueryStringFilter — ?Name=<exact> matches a single row', async ({ request }) => {
+    const target = unique('exact');
+    await request.post('/api/Tags', { data: { name: target, slug: `${target}-slug` } });
+    // A non-match seeded with the same prefix proves the exact-equality semantic.
+    await request.post('/api/Tags', { data: { name: `${target}-decoy`, slug: `${target}-decoy-slug` } });
+
+    const response = await request.get(`/api/Tags?Name=${encodeURIComponent(target)}`);
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.count).toBe(1);
+    expect(body.results[0].name).toBe(target);
+  });
+
+  test('QueryStringSearchFilter — caller supplies LIKE wildcards explicitly', async ({ request }) => {
+    // The library forwards `?search=<term>` to EF.Functions.Like(field, term) without
+    // wrapping the term in `%`. Consumers wanting substring matches MUST include the
+    // wildcards themselves — documented contract.
+    const prefix = unique('searchhit');
+    await request.post('/api/Tags', { data: { name: `${prefix}-rosemary`, slug: `${prefix}-rosemary-slug` } });
+    await request.post('/api/Tags', { data: { name: `${prefix}-thyme`,    slug: `${prefix}-thyme-slug`    } });
+
+    const response = await request.get('/api/Tags', {
+      params: { search: `${prefix}%` },
+    });
+    expect(response.status()).toBe(200);
+    expect((await response.json()).count).toBeGreaterThanOrEqual(2);
+  });
+
+  test('QueryStringIdRangeFilter — ?ids=1&ids=2 returns exactly those rows', async ({ request }) => {
+    const prefix = unique('ids');
+    const ids = await seedTags(request, prefix, 3);
+    const wanted = [ids[0], ids[2]];
+
+    const response = await request.get(`/api/Tags?ids=${wanted[0]}&ids=${wanted[1]}`);
+    expect(response.status()).toBe(200);
+    const returnedIds: number[] = (await response.json()).results.map((r: any) => r.id).sort();
+    expect(returnedIds).toEqual(wanted.sort());
+  });
+
+  test('QueryStringIdRangeFilter — comma-separated form ?ids=1,2,3 also works', async ({ request }) => {
+    const prefix = unique('idscsv');
+    const ids = await seedTags(request, prefix, 3);
+
+    const response = await request.get(`/api/Tags?ids=${ids.join(',')}`);
+    expect(response.status()).toBe(200);
+    expect((await response.json()).count).toBe(3);
+  });
+});
+
+test.describe('Custom Filter<MenuItem> — OnlyAvailableMenuItemsFilter', () => {
+  test('default GET returns both available and unavailable rows', async ({ request }) => {
+    const restaurantCreate = await request.post('/api/Restaurants', {
+      data: { name: unique('FilterHost'), address: 'a', phone: '0' },
+    });
+    const restaurantId = (await restaurantCreate.json()).id;
+
+    const prefix = unique('avail');
+    const onCreate = await request.post('/api/MenuItems', {
+      data: { restaurantId, name: `${prefix}-on`,  description: '', price: 1, isAvailable: true },
+    });
+    const offCreate = await request.post('/api/MenuItems', {
+      data: { restaurantId, name: `${prefix}-off`, description: '', price: 1, isAvailable: false },
+    });
+    const onId = (await onCreate.json()).id;
+    const offId = (await offCreate.json()).id;
+
+    const all = await request.get(`/api/MenuItems?ids=${onId}&ids=${offId}`);
+    expect(all.status()).toBe(200);
+    expect((await all.json()).count).toBe(2);
+  });
+
+  test('?onlyAvailable=true narrows to IsAvailable=true rows', async ({ request }) => {
+    const restaurantCreate = await request.post('/api/Restaurants', {
+      data: { name: unique('FilterHost'), address: 'a', phone: '0' },
+    });
+    const restaurantId = (await restaurantCreate.json()).id;
+
+    const prefix = unique('availonly');
+    const onCreate = await request.post('/api/MenuItems', {
+      data: { restaurantId, name: `${prefix}-on`,  description: '', price: 1, isAvailable: true },
+    });
+    const offCreate = await request.post('/api/MenuItems', {
+      data: { restaurantId, name: `${prefix}-off`, description: '', price: 1, isAvailable: false },
+    });
+    const onId = (await onCreate.json()).id;
+    const offId = (await offCreate.json()).id;
+
+    const onlyAvailable = await request.get(`/api/MenuItems?ids=${onId}&ids=${offId}&onlyAvailable=true`);
+    expect(onlyAvailable.status()).toBe(200);
+    const body = await onlyAvailable.json();
+    expect(body.count).toBe(1);
+    expect(body.results[0].isAvailable).toBe(true);
+    expect(body.results[0].name).toBe(`${prefix}-on`);
+  });
+});

--- a/playwright/tests/openapi.spec.ts
+++ b/playwright/tests/openapi.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Contract assertions against the OpenAPI document exposed by Swashbuckle.
+ *
+ * Pins the consumer-visible surface: every controller in sample-project/Commands/ApiCommand.cs
+ * must produce both a collection path (with GET/POST/DELETE) and an item path (with
+ * GET/PATCH/PUT/DELETE), even when the action is disabled by ActionOptions — disabled
+ * actions stay listed because we gate inline with 405 instead of [NonAction].
+ */
+test.describe('OpenAPI contract', () => {
+  const resources = [
+    'Categories',
+    'Restaurants',
+    'RestaurantProfiles',
+    'Ingredients',
+    'MenuItems',
+    'Gifts',
+    'Tags',
+    'AuditLogs',
+  ];
+
+  test('document is reachable and well-formed', async ({ request }) => {
+    const response = await request.get('/swagger/v1/swagger.json');
+    expect(response.status()).toBe(200);
+
+    const doc = await response.json();
+    expect(doc.openapi).toMatch(/^3\./);
+    expect(doc.info?.title).toBe('SampleProject API');
+    expect(doc.paths).toBeTruthy();
+  });
+
+  test('every resource exposes a collection path with GET/POST/DELETE', async ({ request }) => {
+    const doc = await (await request.get('/swagger/v1/swagger.json')).json();
+
+    for (const resource of resources) {
+      const path = doc.paths[`/api/${resource}`];
+      expect(path, `missing collection path for ${resource}`).toBeTruthy();
+      expect(Object.keys(path).sort()).toEqual(['delete', 'get', 'post']);
+    }
+  });
+
+  test('every resource exposes an item path with GET/PATCH/PUT/DELETE', async ({ request }) => {
+    const doc = await (await request.get('/swagger/v1/swagger.json')).json();
+
+    for (const resource of resources) {
+      const path = doc.paths[`/api/${resource}/{id}`];
+      expect(path, `missing item path for ${resource}`).toBeTruthy();
+      expect(Object.keys(path).sort()).toEqual(['delete', 'get', 'patch', 'put']);
+    }
+  });
+
+  test('disabled actions stay listed (AllowDelete=false on MenuItems still ships DELETE in the schema)', async ({ request }) => {
+    // The library gates inline with 405 instead of [NonAction] so the endpoint stays
+    // visible in OpenAPI / OPTIONS — documented but off by default.
+    const doc = await (await request.get('/swagger/v1/swagger.json')).json();
+    expect(doc.paths['/api/MenuItems/{id}']?.delete).toBeTruthy();
+  });
+
+  test('append-only AuditLogs still ships every verb in the schema (all disabled = inline 405)', async ({ request }) => {
+    const doc = await (await request.get('/swagger/v1/swagger.json')).json();
+    // Collection + item paths exist with the full verb set even though every mutating
+    // action is disabled on the controller — same 405-inline contract as MenuItems above.
+    expect(Object.keys(doc.paths['/api/AuditLogs']).sort()).toEqual(['delete', 'get', 'post']);
+    expect(Object.keys(doc.paths['/api/AuditLogs/{id}']).sort()).toEqual(['delete', 'get', 'patch', 'put']);
+  });
+});

--- a/playwright/tests/restaurants-nested.spec.ts
+++ b/playwright/tests/restaurants-nested.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '@playwright/test';
+import { unique } from '../helpers/data';
+
+/**
+ * Pins the Query-with-Include pattern: RestaurantsController sets
+ *   Query = ctx.Restaurants.Include(r => r.Profile).Include(r => r.MenuItems).AsNoTracking()
+ * so every action's load step sees the eager-loaded navigation, and the configured nested
+ * entries in Restaurant.GetFields() ("RestaurantProfile:Website", "RestaurantProfile:Capacity")
+ * project the included Profile data into the response.
+ */
+test.describe('Restaurants — Query with .Include() projects nested fields', () => {
+  test('GET single returns nested RestaurantProfile fields when a profile exists', async ({ request }) => {
+    const restaurantCreate = await request.post('/api/Restaurants', {
+      data: { name: unique('Linked'), address: '1 Linked Way', phone: '555-NEST' },
+    });
+    expect(restaurantCreate.status()).toBe(201);
+    const restaurant = await restaurantCreate.json();
+
+    const profileCreate = await request.post('/api/RestaurantProfiles', {
+      data: {
+        restaurantId: restaurant.id,
+        website: 'https://nested.example.com',
+        openingHours: '09-23',
+        capacity: 42,
+      },
+    });
+    expect(profileCreate.status()).toBe(201);
+
+    const fetched = await request.get(`/api/Restaurants/${restaurant.id}`);
+    expect(fetched.status()).toBe(200);
+    const body = await fetched.json();
+
+    // Nested-field projection drops the values into the top-level shape that JsonTransform
+    // produces. We assert presence and value — the exact JSON key the library emits.
+    const haystack = JSON.stringify(body);
+    expect(haystack).toContain('https://nested.example.com');
+    expect(haystack).toContain('42');
+  });
+
+  test('GET single still works when no profile exists (no eager-load crash)', async ({ request }) => {
+    const restaurantCreate = await request.post('/api/Restaurants', {
+      data: { name: unique('Bare'), address: 'nowhere', phone: '000' },
+    });
+    expect(restaurantCreate.status()).toBe(201);
+    const id = (await restaurantCreate.json()).id;
+
+    const fetched = await request.get(`/api/Restaurants/${id}`);
+    expect(fetched.status()).toBe(200);
+  });
+});
+
+test.describe('ValidateDestroyAsync — pre-delete state predicate', () => {
+  test('DELETE on a restaurant with menu items returns 400 with a non-field error', async ({ request }) => {
+    const restaurantCreate = await request.post('/api/Restaurants', {
+      data: { name: unique('NonEmpty'), address: '1', phone: '1' },
+    });
+    expect(restaurantCreate.status()).toBe(201);
+    const restaurantId = (await restaurantCreate.json()).id;
+
+    const menuItemCreate = await request.post('/api/MenuItems', {
+      data: {
+        restaurantId,
+        name: unique('SoupOfDay'),
+        description: '',
+        price: 5,
+        isAvailable: true,
+      },
+    });
+    expect(menuItemCreate.status()).toBe(201);
+
+    const del = await request.delete(`/api/Restaurants/${restaurantId}`);
+    expect(del.status()).toBe(400);
+    const body = await del.json();
+    // ValidationErrors.NonFieldErrorsKey is "non_field_errors" (DRF convention).
+    expect(body.error.non_field_errors).toEqual(
+      expect.arrayContaining([expect.stringMatching(/menu items/i)]),
+    );
+  });
+
+  test('DELETE on an empty restaurant still succeeds (hook only fires when predicate is true)', async ({ request }) => {
+    const restaurantCreate = await request.post('/api/Restaurants', {
+      data: { name: unique('Empty'), address: 'x', phone: 'y' },
+    });
+    const id = (await restaurantCreate.json()).id;
+
+    expect((await request.delete(`/api/Restaurants/${id}`)).status()).toBe(204);
+  });
+});

--- a/playwright/tests/tags.spec.ts
+++ b/playwright/tests/tags.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from '@playwright/test';
+import { unique } from '../helpers/data';
+
+/**
+ * Drives the per-field Validate{X}Async hooks on TagSerializer:
+ *   - ValidateNameAsync trims, requires non-empty, enforces uniqueness.
+ *   - ValidateSlugAsync normalizes to lowercase kebab-case, enforces uniqueness.
+ *
+ * Tags are flag-gated like every other resource — full CRUD works.
+ */
+test.describe('Tags — per-field validation hooks', () => {
+  test('happy path: ValidateSlugAsync normalizes the persisted slug', async ({ request }) => {
+    // The slug input is unique-per-run so consecutive playwright runs don't trip the
+    // uniqueness check on a slug that always normalizes to the same value.
+    const name = unique('Spicy Pepper');
+    const rawSlug = `Spicy   ${unique('Pepper')}!!`;
+    const expectedSlug = rawSlug
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+
+    const create = await request.post('/api/Tags', {
+      data: { name, slug: rawSlug },
+    });
+    expect(create.status()).toBe(201);
+    const tag = await create.json();
+    // The hook returned the normalized slug, and that's what got persisted.
+    expect(tag.slug).toBe(expectedSlug);
+    // Name is trimmed, not lowercased — only Slug normalizes.
+    expect(tag.name).toBe(name);
+  });
+
+  test('ValidateNameAsync rejects empty name with field-level error', async ({ request }) => {
+    const response = await request.post('/api/Tags', {
+      data: { name: '   ', slug: unique('slug') },
+    });
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    // Library's ValidationErrors envelope: { type, statusCode, error: { Field: [msg, ...] } }
+    expect(body.statusCode).toBe(400);
+    expect(body.error.Name).toEqual(expect.arrayContaining([expect.stringMatching(/required/i)]));
+  });
+
+  test('ValidateSlugAsync rejects slug that normalizes to empty', async ({ request }) => {
+    const response = await request.post('/api/Tags', {
+      data: { name: unique('Tag'), slug: '!!!---' },
+    });
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    expect(body.error.Slug).toEqual(expect.arrayContaining([expect.stringMatching(/alphanumeric/i)]));
+  });
+
+  test('uniqueness is enforced asynchronously against the database', async ({ request }) => {
+    const name = unique('Persistent');
+    const slug = `persistent-${Date.now().toString(36)}`;
+
+    const first = await request.post('/api/Tags', { data: { name, slug } });
+    expect(first.status()).toBe(201);
+
+    const duplicate = await request.post('/api/Tags', { data: { name, slug: unique('other') } });
+    expect(duplicate.status()).toBe(400);
+    expect((await duplicate.json()).error.Name).toBeTruthy();
+
+    const duplicateSlug = await request.post('/api/Tags', {
+      data: { name: unique('Other Name'), slug },
+    });
+    expect(duplicateSlug.status()).toBe(400);
+    expect((await duplicateSlug.json()).error.Slug).toBeTruthy();
+  });
+
+  test('PATCH skips per-field hooks for omitted fields (partial semantics)', async ({ request }) => {
+    const name = unique('Patchable');
+    const create = await request.post('/api/Tags', {
+      data: { name, slug: unique('patchable-slug').toLowerCase() },
+    });
+    expect(create.status()).toBe(201);
+    const id = (await create.json()).id;
+
+    // Re-PATCHing the same Name onto the same row used to fail "uniqueness" in naive
+    // implementations. The Validate{X}Async hooks receive context.EntityId and exclude
+    // the row's own id, so this succeeds.
+    const patch = await request.patch(`/api/Tags/${id}`, { data: { name } });
+    expect(patch.status()).toBe(200);
+    expect((await patch.json()).name).toBe(name);
+  });
+
+  test('cross-field ValidateAsync rejects when normalized Name equals Slug', async ({ request }) => {
+    // Choose values where per-field uniqueness passes (nothing else in the DB has these),
+    // but the normalized form of Name equals Slug exactly — that's the cross-field rule's
+    // collision condition. Run-unique stamp avoids piling up failed rows over reruns.
+    const stamp = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+    const name = `Cross ${stamp}`;          // normalizes (trim + lower + kebab) to `cross-{stamp}`
+    const slug = `cross-${stamp}`;          // already in the normalized form
+    const response = await request.post('/api/Tags', { data: { name, slug } });
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    expect(body.error.Name).toEqual(expect.arrayContaining([expect.stringMatching(/differ/i)]));
+  });
+
+  test('full CRUD round-trip', async ({ request }) => {
+    const name = unique('Crud');
+    const create = await request.post('/api/Tags', {
+      data: { name, slug: unique('crud-slug').toLowerCase() },
+    });
+    const id = (await create.json()).id;
+
+    expect((await request.get(`/api/Tags/${id}`)).status()).toBe(200);
+
+    const put = await request.put(`/api/Tags/${id}`, {
+      data: { name: unique('Put'), slug: unique('put-slug').toLowerCase() },
+    });
+    expect(put.status()).toBe(200);
+
+    expect((await request.delete(`/api/Tags/${id}`)).status()).toBe(204);
+    expect((await request.get(`/api/Tags/${id}`)).status()).toBe(404);
+  });
+});

--- a/playwright/tsconfig.json
+++ b/playwright/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@helpers/*": ["helpers/*"]
+    }
+  },
+  "include": [
+    "tests/**/*",
+    "helpers/**/*",
+    "playwright.config.ts"
+  ]
+}

--- a/sample-project/appsettings.json
+++ b/sample-project/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Urls": "http://+:8000",
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "AppDbContext": "Data Source=localhost,1433;Initial Catalog=SampleProject;User Id=sa;Password=Password1;TrustServerCertificate=True"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Warning"
+    }
+  }
+}

--- a/sample-project/src/Commands/ApiCommand.cs
+++ b/sample-project/src/Commands/ApiCommand.cs
@@ -1,0 +1,117 @@
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.OpenApi.Models;
+using NDjango.RestFramework.Extensions;
+using Newtonsoft.Json;
+
+namespace SampleProject.Commands;
+
+/// <summary>
+/// Single API command: wires NDjango.RestFramework, SQL Server, Newtonsoft.Json, and Swagger
+/// into a minimal ASP.NET Core host. Controllers live under <c>Controllers/</c>; serializer
+/// subclasses (auto-discovered by <c>AddNDjangoRestFramework</c>) live under <c>Serializers/</c>.
+/// </summary>
+public static class ApiCommand
+{
+    public static async Task RunAsync(string[] args, CancellationToken cancellationToken = default)
+    {
+        // Pin the content root to the binary's output directory so the host's default
+        // configuration probe finds the appsettings.json that the csproj links in via
+        // <Content Include="../appsettings.json" Link="appsettings.json"> regardless of
+        // where `dotnet run` was invoked from.
+        var host = Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(web =>
+            {
+                web.UseContentRoot(AppContext.BaseDirectory);
+                web.UseStartup<Startup>();
+            })
+            .Build();
+
+        // Convenience for the sample: bring the schema up at boot so endpoints work the first time.
+        using (var scope = host.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            await db.Database.EnsureCreatedAsync(cancellationToken);
+        }
+
+        await host.RunAsync(cancellationToken);
+    }
+
+    public class Startup
+    {
+        private readonly IConfiguration _configuration;
+
+        public Startup(IConfiguration configuration) => _configuration = configuration;
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            var connectionString = _configuration.GetConnectionString("AppDbContext");
+
+            services.AddDbContext<AppDbContext>(options => options.UseSqlServer(connectionString));
+
+            // Library wiring: auto-scans this assembly for Serializer<,,,> subclasses and
+            // registers them, plus the startup field-validation hosted service.
+            services.AddNDjangoRestFramework();
+
+            services.AddControllers(options =>
+                {
+                    // Without this opt-out, MVC treats every non-nullable reference type
+                    // property on the DTOs as implicitly [Required]. The PATCH pipeline
+                    // materializes a defaulted PartialJsonObject<T>.Instance before the
+                    // library's serializer runs, so the implicit-required check would 400
+                    // every partial body that omits a string field. Matches the library's
+                    // own test fixture posture.
+                    options.SuppressImplicitRequiredAttributeForNonNullableReferenceTypes = true;
+                })
+                .AddNewtonsoftJson(config =>
+                {
+                    // BaseController renders responses through Newtonsoft.Json — match the
+                    // reference loop posture used in the library tests so navigation properties
+                    // don't blow up serialization.
+                    config.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
+                    config.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
+                });
+
+            services.AddEndpointsApiExplorer();
+            services.AddSwaggerGen(options =>
+            {
+                options.SwaggerDoc("v1", new OpenApiInfo
+                {
+                    Title = "SampleProject API",
+                    Version = "v1",
+                    Description = "Sample consumer of NDjango.RestFramework, used to verify the library by practice."
+                });
+
+                // Pull xmldoc from this project (and any siblings that ship it, including the
+                // library if it is built with GenerateDocumentationFile) so the OpenAPI schema
+                // surfaces the controller and contract notes.
+                var xmlDir = System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+                foreach (var xmlPath in System.IO.Directory.EnumerateFiles(xmlDir, "*.xml"))
+                {
+                    try { options.IncludeXmlComments(xmlPath); }
+                    catch { /* tolerate non-doc xml files in the output dir */ }
+                }
+            });
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
+        {
+            app.UseRouting();
+            app.UseSwagger();
+            app.UseSwaggerUI(options =>
+            {
+                options.SwaggerEndpoint("/swagger/v1/swagger.json", "SampleProject API v1");
+                options.RoutePrefix = "swagger";
+            });
+            app.UseEndpoints(endpoints => endpoints.MapControllers());
+        }
+    }
+}

--- a/sample-project/src/Controllers/AuditLogsController.cs
+++ b/sample-project/src/Controllers/AuditLogsController.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NDjango.RestFramework.Base;
+using NDjango.RestFramework.Filters;
+using SampleProject.Serializers;
+
+namespace SampleProject.Controllers;
+
+/// <summary>
+/// Append-only ledger: only GET and POST are allowed. Every mutating action is disabled via
+/// <see cref="ActionOptions"/>; disabled hits return <c>405 Method Not Allowed</c> while
+/// staying listed in OpenAPI / OPTIONS (documented but off by default — the library's
+/// 405-inline contract, not <c>[NonAction]</c>).
+/// </summary>
+[Route("api/[controller]")]
+[ApiController]
+public class AuditLogsController : BaseController<AuditLogDto, AuditLog, int, AppDbContext>
+{
+    public AuditLogsController(
+        AuditLogSerializer serializer,
+        AppDbContext db,
+        ILogger<AuditLog> logger)
+        : base(
+            serializer,
+            db,
+            new ActionOptions
+            {
+                AllowPatch = false,
+                AllowPut = false,
+                AllowDelete = false,
+                AllowBulkDelete = false,
+            },
+            logger)
+    {
+        AllowedFields = new[]
+        {
+            nameof(AuditLog.Id),
+            nameof(AuditLog.Action),
+            nameof(AuditLog.EntityName),
+        };
+        Filters.Add(new QueryStringFilter<AuditLog>(AllowedFields));
+        Filters.Add(new QueryStringSearchFilter<AuditLog>(AllowedFields));
+        Filters.Add(new QueryStringIdRangeFilter<AuditLog, int>());
+    }
+}

--- a/sample-project/src/Controllers/CategoriesController.cs
+++ b/sample-project/src/Controllers/CategoriesController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NDjango.RestFramework.Base;
+using NDjango.RestFramework.Filters;
+using SampleProject.Serializers;
+
+namespace SampleProject.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class CategoriesController : BaseController<CategoryDto, Category, int, AppDbContext>
+{
+    public CategoriesController(
+        CategorySerializer serializer,
+        AppDbContext db,
+        ILogger<Category> logger)
+        : base(serializer, db, logger)
+    {
+        AllowedFields = new[] { nameof(Category.Id), nameof(Category.Name) };
+        Filters.Add(new QueryStringFilter<Category>(AllowedFields));
+        Filters.Add(new QueryStringSearchFilter<Category>(AllowedFields));
+        Filters.Add(new QueryStringIdRangeFilter<Category, int>());
+    }
+}

--- a/sample-project/src/Controllers/GiftsController.cs
+++ b/sample-project/src/Controllers/GiftsController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NDjango.RestFramework.Base;
+using NDjango.RestFramework.Filters;
+using SampleProject.Serializers;
+
+namespace SampleProject.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class GiftsController : BaseController<GiftDto, Gift, int, AppDbContext>
+{
+    public GiftsController(
+        GiftSerializer serializer,
+        AppDbContext db,
+        ILogger<Gift> logger)
+        : base(serializer, db, logger)
+    {
+        AllowedFields = new[] { nameof(Gift.Id), nameof(Gift.Name), nameof(Gift.IsWrapped) };
+        Filters.Add(new QueryStringFilter<Gift>(AllowedFields));
+        Filters.Add(new QueryStringSearchFilter<Gift>(AllowedFields));
+        Filters.Add(new QueryStringIdRangeFilter<Gift, int>());
+    }
+}

--- a/sample-project/src/Controllers/IngredientsController.cs
+++ b/sample-project/src/Controllers/IngredientsController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NDjango.RestFramework.Base;
+using NDjango.RestFramework.Filters;
+using SampleProject.Serializers;
+
+namespace SampleProject.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class IngredientsController : BaseController<IngredientDto, Ingredient, int, AppDbContext>
+{
+    public IngredientsController(
+        IngredientSerializer serializer,
+        AppDbContext db,
+        ILogger<Ingredient> logger)
+        : base(serializer, db, logger)
+    {
+        AllowedFields = new[] { nameof(Ingredient.Id), nameof(Ingredient.Name), nameof(Ingredient.IsAllergen) };
+        Filters.Add(new QueryStringFilter<Ingredient>(AllowedFields));
+        Filters.Add(new QueryStringSearchFilter<Ingredient>(AllowedFields));
+        Filters.Add(new QueryStringIdRangeFilter<Ingredient, int>());
+    }
+}

--- a/sample-project/src/Controllers/MenuItemsController.cs
+++ b/sample-project/src/Controllers/MenuItemsController.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NDjango.RestFramework.Base;
+using NDjango.RestFramework.Filters;
+using SampleProject.Filters;
+using SampleProject.Serializers;
+
+namespace SampleProject.Controllers;
+
+/// <summary>
+/// Exercises <see cref="ActionOptions.AllowDelete"/>: single-resource DELETE is disabled so a
+/// client that issues <c>DELETE /api/MenuItems/{id}</c> gets <c>405 Method Not Allowed</c> while
+/// the rest of the CRUD surface stays open. The endpoint stays listed in OpenAPI (inline 405,
+/// not [NonAction]) — documented but off by default.
+/// </summary>
+[Route("api/[controller]")]
+[ApiController]
+public class MenuItemsController : BaseController<MenuItemDto, MenuItem, int, AppDbContext>
+{
+    public MenuItemsController(
+        MenuItemSerializer serializer,
+        AppDbContext db,
+        ILogger<MenuItem> logger)
+        : base(serializer, db, new ActionOptions { AllowDelete = false }, logger)
+    {
+        AllowedFields = new[]
+        {
+            nameof(MenuItem.Id),
+            nameof(MenuItem.RestaurantId),
+            nameof(MenuItem.Name),
+            nameof(MenuItem.IsAvailable),
+        };
+        Filters.Add(new QueryStringFilter<MenuItem>(AllowedFields));
+        Filters.Add(new QueryStringSearchFilter<MenuItem>(AllowedFields));
+        Filters.Add(new QueryStringIdRangeFilter<MenuItem, int>());
+        // Domain filter — activates only when ?onlyAvailable=true is on the request.
+        Filters.Add(new OnlyAvailableMenuItemsFilter());
+    }
+}

--- a/sample-project/src/Controllers/RestaurantProfilesController.cs
+++ b/sample-project/src/Controllers/RestaurantProfilesController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NDjango.RestFramework.Base;
+using NDjango.RestFramework.Filters;
+using SampleProject.Serializers;
+
+namespace SampleProject.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class RestaurantProfilesController : BaseController<RestaurantProfileDto, RestaurantProfile, int, AppDbContext>
+{
+    public RestaurantProfilesController(
+        RestaurantProfileSerializer serializer,
+        AppDbContext db,
+        ILogger<RestaurantProfile> logger)
+        : base(serializer, db, logger)
+    {
+        AllowedFields = new[] { nameof(RestaurantProfile.Id), nameof(RestaurantProfile.RestaurantId) };
+        Filters.Add(new QueryStringFilter<RestaurantProfile>(AllowedFields));
+        Filters.Add(new QueryStringIdRangeFilter<RestaurantProfile, int>());
+    }
+}

--- a/sample-project/src/Controllers/RestaurantsController.cs
+++ b/sample-project/src/Controllers/RestaurantsController.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NDjango.RestFramework.Base;
+using NDjango.RestFramework.Errors;
+using NDjango.RestFramework.Filters;
+using NDjango.RestFramework.Helpers;
+using SampleProject.Serializers;
+
+namespace SampleProject.Controllers;
+
+/// <summary>
+/// Demonstrates customizing <see cref="BaseController{TOrigin,TDestination,TPrimaryKey,TContext}.Query"/>
+/// to eager-load navigation properties. The configured Query is what every action filters and
+/// resolves through, so GETs see the included data, and PUT/PATCH/DELETE see scoped rows.
+/// Mirrors the template's <c>PersonsController</c>: <c>Query = ctx.Persons.AsNoTracking();</c>.
+/// </summary>
+[Route("api/[controller]")]
+[ApiController]
+public class RestaurantsController : BaseController<RestaurantDto, Restaurant, int, AppDbContext>
+{
+    private readonly AppDbContext _db;
+
+    public RestaurantsController(
+        RestaurantSerializer serializer,
+        AppDbContext db,
+        ILogger<Restaurant> logger)
+        : base(serializer, db, new ActionOptions { AllowBulkDelete = true }, logger)
+    {
+        _db = db;
+
+        // .Include pulls Profile + MenuItems eagerly. Combined with the nested-field
+        // entries in Restaurant.GetFields() ("RestaurantProfile:Website", ...), the
+        // JsonTransform projects the included Profile fields into responses.
+        Query = db.Restaurants
+            .Include(r => r.Profile)
+            .Include(r => r.MenuItems)
+            .AsNoTracking();
+
+        AllowedFields = new[] { nameof(Restaurant.Id), nameof(Restaurant.Name) };
+        Filters.Add(new QueryStringFilter<Restaurant>(AllowedFields));
+        Filters.Add(new QueryStringSearchFilter<Restaurant>(AllowedFields));
+        Filters.Add(new QueryStringIdRangeFilter<Restaurant, int>());
+    }
+
+    /// <summary>
+    /// Demonstrates <see cref="BaseController{TOrigin,TDestination,TPrimaryKey,TContext}.ValidateDestroyAsync"/>:
+    /// state-predicate that runs after the entity is loaded and before
+    /// <see cref="BaseController{TOrigin,TDestination,TPrimaryKey,TContext}.PerformDestroyAsync"/>.
+    /// Populating <paramref name="errors"/> short-circuits the DELETE with a
+    /// <c>400 ValidationErrors</c> response. Mirrors the README example
+    /// "Store has open orders → cannot be deleted".
+    ///
+    /// <para>
+    /// The bulk-delete path (<c>DELETE ?ids=</c>) bypasses this hook by design — it runs a
+    /// single <c>ExecuteDeleteAsync</c> and skips per-row validation. That's why bulk delete
+    /// is opt-in (<see cref="ActionOptions.AllowBulkDelete"/>); enable it only when the rule
+    /// the bulk path skips is genuinely safe to skip.
+    /// </para>
+    /// </summary>
+    protected override async Task ValidateDestroyAsync(
+        Restaurant instance,
+        IDictionary<string, List<string>> errors,
+        CancellationToken cancellationToken)
+    {
+        var hasMenuItems = await _db.MenuItems.AsNoTracking()
+            .AnyAsync(m => m.RestaurantId == instance.Id, cancellationToken);
+        if (hasMenuItems)
+            errors.GetOrAdd(ValidationErrors.NonFieldErrorsKey)
+                .Add("Cannot delete a restaurant that still has menu items.");
+    }
+}

--- a/sample-project/src/Controllers/TagsController.cs
+++ b/sample-project/src/Controllers/TagsController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NDjango.RestFramework.Base;
+using NDjango.RestFramework.Filters;
+using SampleProject.Serializers;
+
+namespace SampleProject.Controllers;
+
+/// <summary>
+/// Drives the per-field <c>Validate{Field}Async</c> seams on <see cref="TagSerializer"/>:
+/// <c>ValidateNameAsync</c> rejects empty / duplicate names; <c>ValidateSlugAsync</c>
+/// normalizes the slug to lowercase kebab-case and enforces uniqueness.
+/// </summary>
+[Route("api/[controller]")]
+[ApiController]
+public class TagsController : BaseController<TagDto, Tag, int, AppDbContext>
+{
+    public TagsController(
+        TagSerializer serializer,
+        AppDbContext db,
+        ILogger<Tag> logger)
+        : base(serializer, db, logger)
+    {
+        AllowedFields = new[] { nameof(Tag.Id), nameof(Tag.Name), nameof(Tag.Slug) };
+        Filters.Add(new QueryStringFilter<Tag>(AllowedFields));
+        Filters.Add(new QueryStringSearchFilter<Tag>(AllowedFields));
+        Filters.Add(new QueryStringIdRangeFilter<Tag, int>());
+    }
+}

--- a/sample-project/src/Database.cs
+++ b/sample-project/src/Database.cs
@@ -1,0 +1,129 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace SampleProject;
+
+public class AppDbContext : DbContext
+{
+    public DbSet<Category> Categories => Set<Category>();
+    public DbSet<Restaurant> Restaurants => Set<Restaurant>();
+    public DbSet<RestaurantProfile> RestaurantProfiles => Set<RestaurantProfile>();
+    public DbSet<Ingredient> Ingredients => Set<Ingredient>();
+    public DbSet<MenuItem> MenuItems => Set<MenuItem>();
+    public DbSet<MenuItemIngredient> MenuItemIngredients => Set<MenuItemIngredient>();
+    public DbSet<Tag> Tags => Set<Tag>();
+    public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
+    public DbSet<Gift> Gifts => Set<Gift>();
+
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Category>(entity =>
+        {
+            entity.Property(c => c.Name).IsRequired().HasMaxLength(100);
+            entity.HasIndex(c => c.Name).IsUnique();
+            entity.Property(c => c.Description).HasMaxLength(500);
+        });
+
+        modelBuilder.Entity<Restaurant>(entity =>
+        {
+            entity.Property(r => r.Name).IsRequired().HasMaxLength(200);
+            entity.Property(r => r.Address).HasMaxLength(300);
+            entity.Property(r => r.Phone).HasMaxLength(40);
+        });
+
+        modelBuilder.Entity<RestaurantProfile>(entity =>
+        {
+            entity.HasOne(p => p.Restaurant)
+                .WithOne(r => r.Profile)
+                .HasForeignKey<RestaurantProfile>(p => p.RestaurantId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(p => p.Website).HasMaxLength(200);
+            entity.Property(p => p.OpeningHours).HasMaxLength(100);
+        });
+
+        modelBuilder.Entity<MenuItem>(entity =>
+        {
+            entity.HasOne(m => m.Restaurant)
+                .WithMany(r => r.MenuItems)
+                .HasForeignKey(m => m.RestaurantId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(m => m.Name).IsRequired().HasMaxLength(150);
+            entity.Property(m => m.Description).HasMaxLength(500);
+            entity.Property(m => m.Price).HasPrecision(10, 2);
+        });
+
+        modelBuilder.Entity<Ingredient>(entity =>
+        {
+            entity.Property(i => i.Name).IsRequired().HasMaxLength(100);
+            entity.HasIndex(i => i.Name).IsUnique();
+        });
+
+        modelBuilder.Entity<MenuItemIngredient>(entity =>
+        {
+            entity.HasKey(mi => new { mi.MenuItemId, mi.IngredientId });
+            entity.HasOne(mi => mi.MenuItem)
+                .WithMany()
+                .HasForeignKey(mi => mi.MenuItemId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne(mi => mi.Ingredient)
+                .WithMany()
+                .HasForeignKey(mi => mi.IngredientId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<Tag>(entity =>
+        {
+            entity.Property(t => t.Name).IsRequired().HasMaxLength(100);
+            entity.HasIndex(t => t.Name).IsUnique();
+            entity.Property(t => t.Slug).IsRequired().HasMaxLength(100);
+            entity.HasIndex(t => t.Slug).IsUnique();
+        });
+
+        modelBuilder.Entity<AuditLog>(entity =>
+        {
+            entity.Property(a => a.Action).IsRequired().HasMaxLength(50);
+            entity.Property(a => a.EntityName).IsRequired().HasMaxLength(100);
+            entity.Property(a => a.Detail).HasMaxLength(2000);
+        });
+
+        modelBuilder.Entity<Gift>(entity =>
+        {
+            entity.Property(g => g.Name).IsRequired().HasMaxLength(150);
+            entity.Property(g => g.Price).HasPrecision(12, 2);
+            entity.Property(g => g.Description).HasMaxLength(500);
+            entity.Property(g => g.Notes).HasMaxLength(500);
+        });
+    }
+
+    public override int SaveChanges(bool acceptAllChangesOnSuccess)
+    {
+        StampTimestamps();
+        return base.SaveChanges(acceptAllChangesOnSuccess);
+    }
+
+    public override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
+    {
+        StampTimestamps();
+        return base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
+    }
+
+    private void StampTimestamps()
+    {
+        var now = DateTime.UtcNow;
+        foreach (var entry in ChangeTracker.Entries<StandardEntity>())
+        {
+            if (entry.State == EntityState.Added)
+            {
+                entry.Entity.CreatedAt = now;
+                entry.Entity.UpdatedAt = now;
+            }
+            else if (entry.State == EntityState.Modified)
+            {
+                entry.Entity.UpdatedAt = now;
+            }
+        }
+    }
+}

--- a/sample-project/src/Filters/OnlyAvailableMenuItemsFilter.cs
+++ b/sample-project/src/Filters/OnlyAvailableMenuItemsFilter.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Http;
+using NDjango.RestFramework.Filters;
+
+namespace SampleProject.Filters;
+
+/// <summary>
+/// Custom domain filter. Activates only when the request carries
+/// <c>?onlyAvailable=true</c>; otherwise it returns the queryset untouched so the existing
+/// list-all behavior keeps working.
+///
+/// <para>
+/// Mirrors the README's <c>ActiveOnlyFilter</c> / <c>TodoItemIncludePersonFilter</c> shape:
+/// a <see cref="Filter{TEntity}"/> subclass is the right seam whenever an LIST endpoint
+/// needs an EF Core operation that goes beyond <c>QueryStringFilter</c>'s equality match.
+/// </para>
+/// </summary>
+public class OnlyAvailableMenuItemsFilter : Filter<MenuItem>
+{
+    public override IQueryable<MenuItem> AddFilter(IQueryable<MenuItem> query, HttpRequest request)
+    {
+        if (!request.Query.TryGetValue("onlyAvailable", out var raw))
+            return query;
+
+        if (!bool.TryParse(raw, out var only) || !only)
+            return query;
+
+        return query.Where(m => m.IsAvailable);
+    }
+}

--- a/sample-project/src/Models.cs
+++ b/sample-project/src/Models.cs
@@ -1,0 +1,285 @@
+using NDjango.RestFramework.Base;
+
+namespace SampleProject;
+
+/// <summary>
+/// Common base for sample entities: int primary key plus audit columns.
+/// CreatedAt / UpdatedAt are stamped automatically by <see cref="AppDbContext"/> on save.
+/// </summary>
+public abstract class StandardEntity : BaseModel<int>
+{
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+
+public class Category : StandardEntity
+{
+    public string Name { get; set; } = "";
+    public string Description { get; set; } = "";
+
+    public override string[] GetFields() =>
+    [
+        nameof(Id),
+        nameof(Name),
+        nameof(Description),
+        nameof(CreatedAt),
+        nameof(UpdatedAt),
+    ];
+}
+
+public class Restaurant : StandardEntity
+{
+    public string Name { get; set; } = "";
+    public string Address { get; set; } = "";
+    public string Phone { get; set; } = "";
+
+    public RestaurantProfile? Profile { get; set; }
+    public ICollection<MenuItem> MenuItems { get; set; } = new List<MenuItem>();
+
+    public override string[] GetFields() =>
+    [
+        nameof(Id),
+        nameof(Name),
+        nameof(Address),
+        nameof(Phone),
+        nameof(CreatedAt),
+        nameof(UpdatedAt),
+        nameof(Profile),
+        // Nested-field projection — prefix is the navigation's element type name,
+        // not the property name (per BaseController.ResolveAndValidateFields).
+        "RestaurantProfile:Website",
+        "RestaurantProfile:Capacity",
+    ];
+}
+
+public class RestaurantProfile : StandardEntity
+{
+    public int RestaurantId { get; set; }
+    public Restaurant? Restaurant { get; set; }
+
+    public string Website { get; set; } = "";
+    public string OpeningHours { get; set; } = "";
+    public int Capacity { get; set; }
+
+    public override string[] GetFields() =>
+    [
+        nameof(Id),
+        nameof(RestaurantId),
+        nameof(Website),
+        nameof(OpeningHours),
+        nameof(Capacity),
+        nameof(CreatedAt),
+        nameof(UpdatedAt),
+    ];
+}
+
+public class Ingredient : StandardEntity
+{
+    public string Name { get; set; } = "";
+    public bool IsAllergen { get; set; }
+
+    public override string[] GetFields() =>
+    [
+        nameof(Id),
+        nameof(Name),
+        nameof(IsAllergen),
+        nameof(CreatedAt),
+        nameof(UpdatedAt),
+    ];
+}
+
+public class MenuItem : StandardEntity
+{
+    public int RestaurantId { get; set; }
+    public Restaurant? Restaurant { get; set; }
+
+    public string Name { get; set; } = "";
+    public string Description { get; set; } = "";
+    public decimal Price { get; set; }
+    public bool IsAvailable { get; set; } = true;
+
+    public override string[] GetFields() =>
+    [
+        nameof(Id),
+        nameof(RestaurantId),
+        nameof(Name),
+        nameof(Description),
+        nameof(Price),
+        nameof(IsAvailable),
+        nameof(CreatedAt),
+        nameof(UpdatedAt),
+    ];
+}
+
+/// <summary>
+/// Pure join table: no controller, no DTO. Lives in the model to demonstrate that the
+/// library only generates CRUD for types it can see a controller for.
+/// </summary>
+public class MenuItemIngredient
+{
+    public int MenuItemId { get; set; }
+    public MenuItem? MenuItem { get; set; }
+
+    public int IngredientId { get; set; }
+    public Ingredient? Ingredient { get; set; }
+}
+
+/// <summary>
+/// Demonstrates per-field <c>Validate{Field}Async</c> hooks on the matching serializer
+/// (see <c>TagSerializer.ValidateNameAsync</c> / <c>ValidateSlugAsync</c>): the hooks
+/// normalize the inbound value (trim, lowercase, dash-collapse) and run async DB checks
+/// for uniqueness before the row is persisted.
+/// </summary>
+public class Tag : StandardEntity
+{
+    public string Name { get; set; } = "";
+    public string Slug { get; set; } = "";
+
+    public override string[] GetFields() =>
+    [
+        nameof(Id),
+        nameof(Name),
+        nameof(Slug),
+        nameof(CreatedAt),
+        nameof(UpdatedAt),
+    ];
+}
+
+/// <summary>
+/// Demonstrates HTTP-method gating via <see cref="NDjango.RestFramework.Base.ActionOptions"/>:
+/// the matching <c>AuditLogsController</c> only allows GET/POST. PATCH, PUT, single-DELETE,
+/// and bulk-DELETE all return <c>405 Method Not Allowed</c> while staying listed in OpenAPI.
+/// </summary>
+public class AuditLog : StandardEntity
+{
+    public string Action { get; set; } = "";
+    public string EntityName { get; set; } = "";
+    public string? Detail { get; set; }
+
+    public override string[] GetFields() =>
+    [
+        nameof(Id),
+        nameof(Action),
+        nameof(EntityName),
+        nameof(Detail),
+        nameof(CreatedAt),
+        nameof(UpdatedAt),
+    ];
+}
+
+/// <summary>
+/// Wide primitive type surface — exercises OpenAPI schema generation across every CLR primitive
+/// the library is expected to handle.
+/// </summary>
+public class Gift : StandardEntity
+{
+    public string Name { get; set; } = "";
+    public bool IsWrapped { get; set; }
+    public Guid TrackingCode { get; set; }
+    public decimal Price { get; set; }
+    public long Barcode { get; set; }
+    public double Weight { get; set; }
+    public float Rating { get; set; }
+    public short QuantityInStock { get; set; }
+    public byte MinAge { get; set; }
+    public DateTimeOffset ShippedAt { get; set; }
+    public TimeSpan PreparationTime { get; set; }
+    public DateOnly ExpirationDate { get; set; }
+    public TimeOnly AvailableFrom { get; set; }
+    public string Description { get; set; } = "";
+    public string Notes { get; set; } = "";
+
+    public override string[] GetFields() =>
+    [
+        nameof(Id),
+        nameof(Name),
+        nameof(IsWrapped),
+        nameof(TrackingCode),
+        nameof(Price),
+        nameof(Barcode),
+        nameof(Weight),
+        nameof(Rating),
+        nameof(QuantityInStock),
+        nameof(MinAge),
+        nameof(ShippedAt),
+        nameof(PreparationTime),
+        nameof(ExpirationDate),
+        nameof(AvailableFrom),
+        nameof(Description),
+        nameof(Notes),
+        nameof(CreatedAt),
+        nameof(UpdatedAt),
+    ];
+}
+
+#region DTOs
+
+public class CategoryDto : BaseDto<int>
+{
+    public string Name { get; set; } = "";
+    public string Description { get; set; } = "";
+}
+
+public class RestaurantDto : BaseDto<int>
+{
+    public string Name { get; set; } = "";
+    public string Address { get; set; } = "";
+    public string Phone { get; set; } = "";
+}
+
+public class RestaurantProfileDto : BaseDto<int>
+{
+    public int RestaurantId { get; set; }
+    public string Website { get; set; } = "";
+    public string OpeningHours { get; set; } = "";
+    public int Capacity { get; set; }
+}
+
+public class IngredientDto : BaseDto<int>
+{
+    public string Name { get; set; } = "";
+    public bool IsAllergen { get; set; }
+}
+
+public class MenuItemDto : BaseDto<int>
+{
+    public int RestaurantId { get; set; }
+    public string Name { get; set; } = "";
+    public string Description { get; set; } = "";
+    public decimal Price { get; set; }
+    public bool IsAvailable { get; set; } = true;
+}
+
+public class TagDto : BaseDto<int>
+{
+    public string Name { get; set; } = "";
+    public string Slug { get; set; } = "";
+}
+
+public class AuditLogDto : BaseDto<int>
+{
+    public string Action { get; set; } = "";
+    public string EntityName { get; set; } = "";
+    public string? Detail { get; set; }
+}
+
+public class GiftDto : BaseDto<int>
+{
+    public string Name { get; set; } = "";
+    public bool IsWrapped { get; set; }
+    public Guid TrackingCode { get; set; }
+    public decimal Price { get; set; }
+    public long Barcode { get; set; }
+    public double Weight { get; set; }
+    public float Rating { get; set; }
+    public short QuantityInStock { get; set; }
+    public byte MinAge { get; set; }
+    public DateTimeOffset ShippedAt { get; set; }
+    public TimeSpan PreparationTime { get; set; }
+    public DateOnly ExpirationDate { get; set; }
+    public TimeOnly AvailableFrom { get; set; }
+    public string Description { get; set; } = "";
+    public string Notes { get; set; } = "";
+}
+
+#endregion

--- a/sample-project/src/Program.cs
+++ b/sample-project/src/Program.cs
@@ -1,0 +1,8 @@
+using SampleProject.Commands;
+
+namespace SampleProject;
+
+public class Program
+{
+    public static Task Main(string[] args) => ApiCommand.RunAsync(args);
+}

--- a/sample-project/src/SampleProject.csproj
+++ b/sample-project/src/SampleProject.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>SampleProject</RootNamespace>
+    <AssemblyName>SampleProject</AssemblyName>
+    <!-- Surface xmldoc into the generated OpenAPI document so the schema reflects -->
+    <!-- the library's contract notes when inspected via Swagger UI. -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="../appsettings.json" Link="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Newtonsoft is mandatory: BaseController serializes responses through it. -->
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.*" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NDjango.RestFramework\NDjango.RestFramework.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sample-project/src/Serializers/AuditLogSerializer.cs
+++ b/sample-project/src/Serializers/AuditLogSerializer.cs
@@ -1,0 +1,8 @@
+using NDjango.RestFramework.Serializer;
+
+namespace SampleProject.Serializers;
+
+public class AuditLogSerializer : Serializer<AuditLogDto, AuditLog, int, AppDbContext>
+{
+    public AuditLogSerializer(AppDbContext db) : base(db) { }
+}

--- a/sample-project/src/Serializers/CategorySerializer.cs
+++ b/sample-project/src/Serializers/CategorySerializer.cs
@@ -1,0 +1,8 @@
+using NDjango.RestFramework.Serializer;
+
+namespace SampleProject.Serializers;
+
+public class CategorySerializer : Serializer<CategoryDto, Category, int, AppDbContext>
+{
+    public CategorySerializer(AppDbContext db) : base(db) { }
+}

--- a/sample-project/src/Serializers/GiftSerializer.cs
+++ b/sample-project/src/Serializers/GiftSerializer.cs
@@ -1,0 +1,8 @@
+using NDjango.RestFramework.Serializer;
+
+namespace SampleProject.Serializers;
+
+public class GiftSerializer : Serializer<GiftDto, Gift, int, AppDbContext>
+{
+    public GiftSerializer(AppDbContext db) : base(db) { }
+}

--- a/sample-project/src/Serializers/IngredientSerializer.cs
+++ b/sample-project/src/Serializers/IngredientSerializer.cs
@@ -1,0 +1,8 @@
+using NDjango.RestFramework.Serializer;
+
+namespace SampleProject.Serializers;
+
+public class IngredientSerializer : Serializer<IngredientDto, Ingredient, int, AppDbContext>
+{
+    public IngredientSerializer(AppDbContext db) : base(db) { }
+}

--- a/sample-project/src/Serializers/MenuItemSerializer.cs
+++ b/sample-project/src/Serializers/MenuItemSerializer.cs
@@ -1,0 +1,8 @@
+using NDjango.RestFramework.Serializer;
+
+namespace SampleProject.Serializers;
+
+public class MenuItemSerializer : Serializer<MenuItemDto, MenuItem, int, AppDbContext>
+{
+    public MenuItemSerializer(AppDbContext db) : base(db) { }
+}

--- a/sample-project/src/Serializers/RestaurantProfileSerializer.cs
+++ b/sample-project/src/Serializers/RestaurantProfileSerializer.cs
@@ -1,0 +1,8 @@
+using NDjango.RestFramework.Serializer;
+
+namespace SampleProject.Serializers;
+
+public class RestaurantProfileSerializer : Serializer<RestaurantProfileDto, RestaurantProfile, int, AppDbContext>
+{
+    public RestaurantProfileSerializer(AppDbContext db) : base(db) { }
+}

--- a/sample-project/src/Serializers/RestaurantSerializer.cs
+++ b/sample-project/src/Serializers/RestaurantSerializer.cs
@@ -1,0 +1,8 @@
+using NDjango.RestFramework.Serializer;
+
+namespace SampleProject.Serializers;
+
+public class RestaurantSerializer : Serializer<RestaurantDto, Restaurant, int, AppDbContext>
+{
+    public RestaurantSerializer(AppDbContext db) : base(db) { }
+}

--- a/sample-project/src/Serializers/TagSerializer.cs
+++ b/sample-project/src/Serializers/TagSerializer.cs
@@ -1,0 +1,130 @@
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+using NDjango.RestFramework.Helpers;
+using NDjango.RestFramework.Serializer;
+
+namespace SampleProject.Serializers;
+
+/// <summary>
+/// Demonstrates per-field validation hooks. The library auto-discovers
+/// <c>Validate{PropertyName}Async</c> methods on the serializer subclass and runs them
+/// before <see cref="Serializer{TOrigin,TDestination,TPrimaryKey,TContext}.ValidateAsync"/>.
+///
+/// <para>
+/// Each hook returns the (optionally normalized) value that ends up in the persisted entity —
+/// DRF semantics: the returned value replaces the inbound value. Populate <c>errors</c> to
+/// short-circuit the request with a <see cref="NDjango.RestFramework.Errors.ValidationErrors"/>
+/// 400 envelope.
+/// </para>
+///
+/// <para>
+/// On PARTIAL UPDATE (PATCH), per-field hooks only fire for fields the payload actually
+/// carried — the library threads the partial's <c>IsSet</c> probe through the pipeline
+/// so omitted fields don't get re-validated against a defaulted value.
+/// </para>
+/// </summary>
+public class TagSerializer : Serializer<TagDto, Tag, int, AppDbContext>
+{
+    private static readonly Regex NonAlphanumericRun = new("[^a-z0-9]+", RegexOptions.Compiled);
+    private static readonly Regex MultipleDashes = new("-{2,}", RegexOptions.Compiled);
+
+    public TagSerializer(AppDbContext db) : base(db) { }
+
+    /// <summary>
+    /// Required, non-empty, max 100 chars, unique per database. Trims surrounding whitespace.
+    /// The trimmed value is what gets persisted (and what the response echoes back).
+    /// </summary>
+    public async Task<string> ValidateNameAsync(
+        string value,
+        ValidationContext<int> context,
+        IDictionary<string, List<string>> errors,
+        CancellationToken cancellationToken)
+    {
+        var trimmed = (value ?? string.Empty).Trim();
+
+        if (trimmed.Length == 0)
+        {
+            errors.GetOrAdd(nameof(TagDto.Name)).Add("Name is required.");
+            return trimmed;
+        }
+
+        if (trimmed.Length > 100)
+        {
+            errors.GetOrAdd(nameof(TagDto.Name)).Add("Name must be at most 100 characters.");
+            return trimmed;
+        }
+
+        var clashes = await _dbContext.Tags.AsNoTracking()
+            .Where(t => t.Name == trimmed && t.Id != context.EntityId)
+            .AnyAsync(cancellationToken);
+        if (clashes)
+            errors.GetOrAdd(nameof(TagDto.Name)).Add("A tag with this name already exists.");
+
+        return trimmed;
+    }
+
+    /// <summary>
+    /// Normalizes to lowercase kebab-case (alphanumeric runs joined by single dashes) and
+    /// enforces uniqueness. Demonstrates the value-replacing return — the persisted slug is
+    /// the normalized form, not the raw input.
+    /// </summary>
+    public async Task<string> ValidateSlugAsync(
+        string value,
+        ValidationContext<int> context,
+        IDictionary<string, List<string>> errors,
+        CancellationToken cancellationToken)
+    {
+        var raw = (value ?? string.Empty).Trim().ToLowerInvariant();
+        var normalized = NonAlphanumericRun.Replace(raw, "-");
+        normalized = MultipleDashes.Replace(normalized, "-").Trim('-');
+
+        if (normalized.Length == 0)
+        {
+            errors.GetOrAdd(nameof(TagDto.Slug))
+                .Add("Slug must contain at least one alphanumeric character.");
+            return normalized;
+        }
+
+        var clashes = await _dbContext.Tags.AsNoTracking()
+            .Where(t => t.Slug == normalized && t.Id != context.EntityId)
+            .AnyAsync(cancellationToken);
+        if (clashes)
+            errors.GetOrAdd(nameof(TagDto.Slug)).Add("A tag with this slug already exists.");
+
+        return normalized;
+    }
+
+    /// <summary>
+    /// Cross-field rule: <c>ValidateAsync</c> runs <i>only after</i> every per-field hook
+    /// has succeeded (no errors), so we can safely assume <c>Name</c> is already trimmed
+    /// and <c>Slug</c> is already normalized. Mirrors the README example
+    /// "Name cannot be the same as CNPJ".
+    ///
+    /// <para>
+    /// On PATCH, only fields the payload actually carried have been re-run through their
+    /// per-field hooks; <see cref="ValidationContext{T}.IsSet"/> tells us which. Skipping
+    /// the rule when either field is absent matches the partial-update semantics — the
+    /// caller hasn't expressed an opinion on the absent field, so we shouldn't reject
+    /// based on a defaulted value.
+    /// </para>
+    /// </summary>
+    public override Task<TagDto> ValidateAsync(
+        TagDto data,
+        ValidationContext<int> context,
+        IDictionary<string, List<string>> errors,
+        CancellationToken cancellationToken = default)
+    {
+        if (!context.IsSet(nameof(TagDto.Name)) || !context.IsSet(nameof(TagDto.Slug)))
+            return Task.FromResult(data);
+
+        var nameAsSlug = MultipleDashes.Replace(
+            NonAlphanumericRun.Replace((data.Name ?? string.Empty).Trim().ToLowerInvariant(), "-"),
+            "-").Trim('-');
+
+        if (!string.IsNullOrEmpty(nameAsSlug) && nameAsSlug == data.Slug)
+            errors.GetOrAdd(nameof(TagDto.Name))
+                .Add("Name and Slug must differ once normalized.");
+
+        return Task.FromResult(data);
+    }
+}

--- a/sample-project/src/packages.lock.json
+++ b/sample-project/src/packages.lock.json
@@ -1,0 +1,1063 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net8.0": {
+      "Microsoft.AspNetCore.Mvc.NewtonsoftJson": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.26",
+        "contentHash": "2fGEeAA/1v2CnnXIDWkOvWy9hSa37X/3L/DtxPT076APAL9dmR6jxa6yV4wC1CQVRkv2db676Xo+exSeu5XGjA==",
+        "dependencies": {
+          "Microsoft.AspNetCore.JsonPatch": "8.0.26",
+          "Newtonsoft.Json": "13.0.3",
+          "Newtonsoft.Json.Bson": "1.0.2"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.SqlServer": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.26",
+        "contentHash": "OdAlRZd5yAZvLaNJ4N9CkRghtiE9K5g+o4ttUqhAS2MmwMmPSqwiEslCLQd9kNo4+ipcdXL4yqGJ6BTVjXpF4Q==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "5.1.7",
+          "Microsoft.EntityFrameworkCore.Relational": "8.0.26",
+          "System.Formats.Asn1": "8.0.2"
+        }
+      },
+      "Swashbuckle.AspNetCore": {
+        "type": "Direct",
+        "requested": "[6.*, )",
+        "resolved": "6.9.0",
+        "contentHash": "lvI+XHF21tkwXd2nDCLGJsdhdUYsY3Ax2fWUlvw81Oa6EedtnIAf5tThy8ZnPcz/9/TwsLgjgtX9ifOCIjbEPA==",
+        "dependencies": {
+          "Microsoft.Extensions.ApiDescription.Server": "6.0.5",
+          "Swashbuckle.AspNetCore.Swagger": "6.9.0",
+          "Swashbuckle.AspNetCore.SwaggerGen": "6.9.0",
+          "Swashbuckle.AspNetCore.SwaggerUI": "6.9.0"
+        }
+      },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.38.0",
+        "contentHash": "IuEgCoVA0ef7E4pQtpC3+TkPbzaoQfa77HlfJDmfuaJUCVJmn7fT0izamZiryW5sYUFKizsftIxMkXKbgIcPMQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "1.1.1",
+          "System.ClientModel": "1.0.0",
+          "System.Diagnostics.DiagnosticSource": "6.0.1",
+          "System.Memory.Data": "1.0.2",
+          "System.Numerics.Vectors": "4.5.0",
+          "System.Text.Encodings.Web": "4.7.2",
+          "System.Text.Json": "4.7.2",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Azure.Identity": {
+        "type": "Transitive",
+        "resolved": "1.11.4",
+        "contentHash": "Sf4BoE6Q3jTgFkgBkx7qztYOFELBCo+wQgpYDwal/qJ1unBH73ywPztIJKXBXORRzAeNijsuxhk94h0TIMvfYg==",
+        "dependencies": {
+          "Azure.Core": "1.38.0",
+          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
+          "System.Memory": "4.5.4",
+          "System.Security.Cryptography.ProtectedData": "4.7.0",
+          "System.Text.Json": "4.7.2",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "ve6uvLwKNRkfnO/QeN9M8eUJ49lCnWv/6/9p6iTEuiI6Rtsz+myaBAjdMzLuTViQY032xbTF5AdZF5BJzJJyXQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.Core": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "gnLnKGawBjqBnU9fEuel3VcYAARkjyONAliaGDfMc8o8HBtfh+HrOPEoR8Xx4b2RnMb7uxdBDOvEAC7sul79ig==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Http": "2.3.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0"
+        }
+      },
+      "Microsoft.AspNetCore.Authorization": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "2/aBgLqBXva/+w8pzRNY8ET43Gi+dr1gv/7ySfbsh23lTK6IAgID5MGUEa1hreNIF+0XpW4tX7QwVe70+YvaPg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Microsoft.AspNetCore.Authorization.Policy": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "vn31uQ1dA1MIV2WNNDOOOm88V5KgR9esfi0LyQ6eVaGq2h0Yw+R29f5A6qUNJt+RccS3qkYayylAy9tP1wV+7Q==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Authorization": "2.3.0"
+        }
+      },
+      "Microsoft.AspNetCore.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "4ivq53W2k6Nj4eez9wc81ytfGj6HR1NaZJCpOrvghJo9zHuQF57PLhPoQH5ItyCpHXnrN/y7yJDUm+TGYzrx0w==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1"
+        }
+      },
+      "Microsoft.AspNetCore.Hosting.Server.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "F5iHx7odAbFKBV1DNPDkFFcVmD5Tk7rk+tYm3LMQxHEFFdjlg5QcYb5XhHAefl5YaaPeG6ad+/ck8kSG3/D6kw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Features": "2.3.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
+        }
+      },
+      "Microsoft.AspNetCore.Http": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "I9azEG2tZ4DDHAFgv+N38e6Yhttvf+QjE2j2UYyCACE7Swm5/0uoihCMWZ87oOZYeqiEFSxbsfpT71OYHe2tpw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.WebUtilities": "2.3.0",
+          "Microsoft.Extensions.ObjectPool": "8.0.11",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Net.Http.Headers": "2.3.0"
+        }
+      },
+      "Microsoft.AspNetCore.Http.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.9",
+        "contentHash": "ULScB/0S9+qvf+yahjR+oQUp0GrvoDHJ9XS5gTqSjLjbjUDnHaJ1s8wo3RJMpaDfb1bawX4OgQM+YmvCUveR4Q==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Features": "2.3.0",
+          "System.Text.Encodings.Web": "8.0.0"
+        }
+      },
+      "Microsoft.AspNetCore.Http.Extensions": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "EY2u/wFF5jsYwGXXswfQWrSsFPmiXsniAlUWo3rv/MGYf99ZFsENDnZcQP6W3c/+xQmQXq0NauzQ7jyy+o1LDQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
+          "Microsoft.Net.Http.Headers": "2.3.0",
+          "System.Buffers": "4.6.0"
+        }
+      },
+      "Microsoft.AspNetCore.Http.Features": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "f10WUgcsKqrkmnz6gt8HeZ7kyKjYN30PO7cSic1lPtH7paPtnQqXPOveul/SIPI43PhRD4trttg4ywnrEmmJpA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.AspNetCore.JsonPatch": {
+        "type": "Transitive",
+        "resolved": "8.0.26",
+        "contentHash": "y4kI9AVsLyd94E7X7XUNDLU/k/HNaeIACxR/nItCRYdmLxAK/TAOM48+SJEWgNtWmieDQZFqH19T3bi4DUWlmw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.7.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.AspNetCore.Mvc.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "xrF8Fh10hEAS6Qp967IgPqNw2iz3/3Q8FQo+Jowbytaj1JJN86p0z851hSH4XP/sFnI5gFu7mGdkplirAJMWPw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Routing.Abstractions": "2.3.0",
+          "Microsoft.Net.Http.Headers": "2.3.0"
+        }
+      },
+      "Microsoft.AspNetCore.Mvc.Core": {
+        "type": "Transitive",
+        "resolved": "2.3.9",
+        "contentHash": "lir+8KX+kFjaUYFDw6R1kJAxBPOAjSKrLEji/rW+h8ePqloVZ5xnzlPttGUPbOkvMXIQKW3mCvtUfVlqCagX5Q==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.Core": "2.3.0",
+          "Microsoft.AspNetCore.Authorization.Policy": "2.3.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Http": "2.3.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Routing": "2.3.0",
+          "Microsoft.Extensions.DependencyInjection": "8.0.1",
+          "Microsoft.Extensions.DependencyModel": "2.1.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
+          "System.Threading.Tasks.Extensions": "4.6.0"
+        }
+      },
+      "Microsoft.AspNetCore.ResponseCaching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "VTqhxnUiawKS22fss5fr/NMJ4MVQHFUgqyWOIaJ9pUY+jmYGCAa+VYfB5DLJYmsD4AhdKnlO6I9lML5tUbDNNA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.AspNetCore.Routing": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "no5/VC0CAQuT4PK4rp2K5fqwuSfzr2mdB6m1XNfWVhHnwzpRQzKAu9flChiT/JTLKwVI0Vq2MSmSW2OFMDCNXg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
+          "Microsoft.AspNetCore.Routing.Abstractions": "2.3.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.ObjectPool": "8.0.11",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Microsoft.AspNetCore.Routing.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "ZkFpUrSmp6TocxZLBEX3IBv5dPMbQuMs6L/BPl0WRfn32UVOtNYJQ0bLdh3cL9LMV0rmTW/5R0w8CBYxr0AOUw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.3.0"
+        }
+      },
+      "Microsoft.AspNetCore.WebUtilities": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "trbXdWzoAEUVd0PE2yTopkz4kjZaAIA7xUWekd5uBw+7xE8Do/YOVTeb9d9koPTlbtZT539aESJjSLSqD8eYrQ==",
+        "dependencies": {
+          "Microsoft.Net.Http.Headers": "2.3.0",
+          "System.Text.Encodings.Web": "8.0.0"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "yuvf07qFWFqtK3P/MRkEKLhn5r2UbSpVueRziSqj0yJQIKFwG1pq9mOayK3zE5qZCTs0CbrwL9M6R8VwqyGy2w=="
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "pTj+D3uJWyN3My70i2Hqo+OXixq3Os2D1nJ2x92FFo6sk8fYS1m1WLNTs0Dc1uPaViH0YvEEwvzddQ7y4rhXmA=="
+      },
+      "Microsoft.Data.SqlClient": {
+        "type": "Transitive",
+        "resolved": "5.1.7",
+        "contentHash": "awBwR6pCRyiFqB5z1iu+eMaFmt986JWgaA1+LR+vsdIRBgeBI5X8f3u+ZPnTqlHUwfTugl6ptIObzalWeAPugQ==",
+        "dependencies": {
+          "Azure.Identity": "1.11.4",
+          "Microsoft.Data.SqlClient.SNI.runtime": "5.1.2",
+          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
+          "Microsoft.SqlServer.Server": "1.0.0",
+          "System.Configuration.ConfigurationManager": "6.0.1",
+          "System.Diagnostics.DiagnosticSource": "6.0.1",
+          "System.Runtime.Caching": "6.0.0",
+          "System.Security.Cryptography.Cng": "5.0.0",
+          "System.Security.Principal.Windows": "5.0.0",
+          "System.Text.Encoding.CodePages": "6.0.0",
+          "System.Text.Encodings.Web": "6.0.1"
+        }
+      },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "5.1.2",
+        "contentHash": "Q3mjL/oG7rYKDI1D34HLxf0FvhEAwOGzbiDfwv9/HaGP9f9yNV8KeXAS6ehxOaoBNqBRM6sTA19f9XVtf8rvLA=="
+      },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "9KPDwvb/hLEVXYruVHVZ8BkebC8j17DmPb56LnqRF74HqSPLjCkrlFUjOtFpQPA2DeADBRTI/e69aCfRBfrhxw==",
+        "dependencies": {
+          "System.AppContext": "4.1.0",
+          "System.Collections": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Transitive",
+        "resolved": "8.0.26",
+        "contentHash": "lOBe7qWbtS4UBPZCDjwbDqDgJFgnPHA5duKEae0RrW67q3EyX3mnE3vPdJ3pFWtTFPcCX0V/7wFX/xE4SkJ2og==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "8.0.26",
+          "Microsoft.EntityFrameworkCore.Analyzers": "8.0.26",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Extensions.Logging": "8.0.1"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.26",
+        "contentHash": "UVXlDz6os+VLpCjEcCjxexXyrxlq7vM3OD2KnyQlnzM9Q8WCsKNI+1PJiR2B6Em+yDCROSHy1jPNXaqxrzrCPQ=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "8.0.26",
+        "contentHash": "uKIwY5fy7Xk3BrWMxryYyzQuzQxmhQADjZqXanXa27vE3vll8QHcUZuI1J1vyPu0bzyBITGdw9nJKDCsJmIHjg=="
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "Transitive",
+        "resolved": "8.0.26",
+        "contentHash": "u9+JYECGPFyEtfsym+e8inVb9e0vnp+Nn80aTOmUj/AxdJ7GqM9lvO/CSgDs7BtDtMFwjK+r8h977zsXbSzT+Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "8.0.26",
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.ApiDescription.Server": {
+        "type": "Transitive",
+        "resolved": "6.0.5",
+        "contentHash": "Ckb5EDBUNJdFWyajfXzUIMRkhf52fHZOQuuZg/oiu8y7zDCVwD0iHhew6MnThjHmevanpxL3f5ci2TtHQEN6bw=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "HFDnhYLccngrzyGgHkjEDU5FMLn4MpOsr5ElgsBMC4yx6lJh4jeWO7fHS8+TXPq+dgxCmUa/Trl8svObmwW4QA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3lE/iLSutpgX1CC0NOW70FJoGARRHbyKmG7dc0klnUZ9Dd9hS6N/POPWhKhMLCEuNN5nXEY5agmlFtH562vqhQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "BmANAnR5Xd4Oqw7yQ75xOAYODybZQRzdeNucg7kS5wWKd2PNnMdYtJ2Vciy0QLylRmv42DGl5+AFL9izA6F1Rw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "nS2XKqi+1A1umnYNLX2Fbm/XnzCxs5i+zXVJ3VC6r9t2z0NZr9FLnJN4VQpKigdcWH/iFTbMuX6M6WQJcTjVIg==",
+        "dependencies": {
+          "Microsoft.DotNet.PlatformAbstractions": "2.1.0",
+          "Newtonsoft.Json": "9.0.1",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Linq": "4.1.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "elH2vmwNmsXuKmUeMQ4YW9ldXiF+gSGDgg1vORksob5POnpaI6caj1Hu8zaYbEuibhqCoWg0YRWDazBY3zjBfg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "ZbaMlhJlpisjuWbvXr4LdAst/1XxH3vZ6A0BsgTphZ2L4PGuxRLz7Jr/S7mkAAnOn78Vu0fKhEgNF5JO3zfjqQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "nHwq9aPBdBPYXPti6wYEEfgXddfBrYC+CQLn+qISiwQq5tpfaqDZSKOJNxoe9rfQxGf1c+2wC/qWFe1QYJPYqw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "4x+pzsQEbqxhNf1QYRr5TDkLP9UsLT3A6MdRKDDEgrW7h1ljiEPgTNhKYUhNCCAaVpQECVQ+onA91PTPnIp6Lw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "8.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "8.0.11",
+        "contentHash": "6ApKcHNJigXBfZa6XlDQ8feJpq7SG1ogZXg6M4FiNzgd6irs3LUAzo0Pfn4F2ZI9liGnH1XIBR/OtSbZmJAV5w=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "dWGKvhFybsaZpGmzkGCbNNwBD1rVlWzrZKANLW/CcbFJpCEceMCGzT7zZwHOGBCbwM0SzBuceMj5HN1LKV1QqA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bXJEZrW9ny8vjMF1JV253WeLhpEVzFo1lyaZu1vQ4ZxWUlVvknZ/+ftFgVheLubb4eZPSwwxBeqS1JkCOjxd8g=="
+      },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.61.3",
+        "contentHash": "naJo/Qm35Caaoxp5utcw+R8eU8ZtLz2ALh8S+gkekOYQ1oazfCQMWVT4NJ/FnHzdIJlm8dMz0oMpMGCabx5odA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "6.35.0",
+          "System.Diagnostics.DiagnosticSource": "6.0.1"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.61.3",
+        "contentHash": "PWnJcznrSGr25MN8ajlc2XIDW4zCFu0U6FkpaNLEWLgd1NgFCp5uDY3mqLDgM8zCN8hqj8yo5wHYfLB2HjcdGw==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.61.3",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "xuR8E4Rd96M41CnUSCiOJ2DBh+z+zQSmyrYHdYhD6K4fXBcQGVnRCFQ0efROUYpP+p0zC1BLKr0JRpVuujTZSg=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "9wxai3hKgZUb4/NjdRKfQd0QJvtXKDlvmGMYACbEC8DFaicMFCFhQFZq9ZET1kJLwZahf2lfY5Gtcpsx8zYzbg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "6.35.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encodings.Web": "4.7.2",
+          "System.Text.Json": "4.7.2"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "jePrSfGAmqT81JDCNSY+fxVWoGuJKt9e6eJ+vT7+quVS55nWl//jGjUQn4eFtVKt4rt5dXaleZdHRB9J9AJZ7Q==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "6.35.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "BPQhlDzdFvv1PzaUxNSk+VEPwezlDEVADIKmyxubw7IiELK18uJ06RQ9QKKkds30XI+gDu9n8j24XQ8w7fjWcg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "6.35.0",
+          "Microsoft.IdentityModel.Tokens": "6.35.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "LMtVqnECCCdSmyFoCOxIE5tXQqkOLrvGrL7OxHg41DIm1bpWtaCdGyVcTAfOQpJXvzND9zUKIN/lhngPkYR8vg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "6.35.0",
+          "System.IdentityModel.Tokens.Jwt": "6.35.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "RN7lvp7s3Boucg1NaNAbqDbxtlLj5Qeb+4uSS1TeK5FSBVM40P4DKaTKChT43sHyKfh7V0zkrMph6DdHvyA4bg==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.5.0",
+          "Microsoft.IdentityModel.Logging": "6.35.0",
+          "System.Security.Cryptography.Cng": "4.5.0"
+        }
+      },
+      "Microsoft.Net.Http.Headers": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "/M0wVg6tJUOHutWD3BMOUVZAioJVXe0tCpFiovzv0T9T12TBf4MnaHP0efO8TCr1a6O9RZgQeZ9Gdark8L9XdA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0",
+          "System.Buffers": "4.6.0"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "aOZA3BWfz9RXjpzt0sRJJMjAscAUm3Hoa4UWAfceV9UTYxgwZ1lZt5nO2myFf+/jetYQo4uTP7zS8sJY67BBxg=="
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "1.6.14",
+        "contentHash": "tTaBT8qjk3xINfESyOPE2rIellPvB7qpVqiWiyA/lACVvz+xOGiXhFUfohcx82NLbi5avzLW0lx+s6oAqQijfw=="
+      },
+      "Microsoft.SqlServer.Server": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
+      },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Newtonsoft.Json.Bson": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "QYFyxhaABwmq3p/21VrZNYvCg3DaEoN/wUuw5nmfAf0X3HLjgupwhkEWdgfb9nvGAUIv3osmZoD3kKl4jxEmYQ==",
+        "dependencies": {
+          "Newtonsoft.Json": "12.0.1"
+        }
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "QfS/nQI7k/BLgmLrw7qm7YBoULEvgWnPI+cYsbfCVFTW8Aj+i8JhccxcFMu1RWms0YZzF+UHguNBK4Qn89e2Sg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1"
+        }
+      },
+      "Swashbuckle.AspNetCore.Swagger": {
+        "type": "Transitive",
+        "resolved": "6.9.0",
+        "contentHash": "P316kpxx5DnDvJwNWW8iTAXkh9DVenAxFGe9v4OUS0gil+vitH7F1feXhCtVeHN/616EFNTMh4pV2lcr9kkw/w==",
+        "dependencies": {
+          "Microsoft.OpenApi": "1.6.14"
+        }
+      },
+      "Swashbuckle.AspNetCore.SwaggerGen": {
+        "type": "Transitive",
+        "resolved": "6.9.0",
+        "contentHash": "FjeMR3fBzwVc5plfYjoHw9ptf8SOWMupvO9X35J5EgzT3L9dRqSxa+cBKzL8PwCyemY0xNrggQSB5+MFWx1axg==",
+        "dependencies": {
+          "Swashbuckle.AspNetCore.Swagger": "6.9.0"
+        }
+      },
+      "Swashbuckle.AspNetCore.SwaggerUI": {
+        "type": "Transitive",
+        "resolved": "6.9.0",
+        "contentHash": "0OxlWBFLl2gUESZX/K7QCTz9KctKy0VxHTvLIBcyWGD4z/fv5MCMW02qzYGcReLJr4yBnNDRzApKtLh6oBpe9A=="
+      },
+      "System.AppContext": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "3QjO4jNV7PdKkmQAVp9atA+usVnKRwI3Kx1nMwJ93T0LcQfx7pKAYk0nKz5wn1oP5iqlhZuy6RXOFdhr7rDwow==",
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.6.0",
+        "contentHash": "lN6tZi7Q46zFzAbRYXTIvfXcyvQQgxnY7Xm6C6xQ9784dEL1amjM6S6Iw4ZpsvesAKnRVsM4scrDQaDqSClkjA=="
+      },
+      "System.ClientModel": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "I3CVkvxeqFYjIVEP59DnjbeoGNfo/+SZrCLpRz2v/g0gpCHaEMPtWSY0s9k/7jR1rAsLNg2z2u1JRB76tPjnIw==",
+        "dependencies": {
+          "System.Memory.Data": "1.0.2",
+          "System.Text.Json": "4.7.2"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "YUJGz6eFKqS0V//mLt25vFGrrCvOnsXjlvFQs+KimpwNxug9x0Pzy4PlFMU3Q2IzqAa9G2L4LsK3+9vCBK7oTg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "jXw9MlUu/kRfEU0WyTptAVueupqIeE3/rl0EZDMlf8pcvJnitQ8HeVEp69rZdaStXwTV72boi/Bhw8lOeO+U2w==",
+        "dependencies": {
+          "System.Security.Cryptography.ProtectedData": "6.0.0",
+          "System.Security.Permissions": "6.0.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "w5U95fVKHY4G8ASs/K5iK3J5LY+/dLFd4vKejsnI/ZhBsWS9hQakfx3Zr7lRWKg4tAw9r4iktyvsTagWkqYCiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "vaoWjvkG1aenR2XdjaVivlCV9fADfgyhW5bZtXT23qaEea0lWiUljdQuze4E31vKM7ZWJaSUsbYIKE3rnzfZUg=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
+        }
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "db34f6LHYM0U0JpE+sOmjar27BnqTVkbLJhgfwMpTdgTigG/Hna3m2MYVwnFzGGKnEJk2UXFuoVTr8WUbU91/A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Formats.Asn1": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "yUsFqNGa7tbwm5QOOnOR3VSoh8a0Yki39mTbhOnErdbg8hVSFtrK0EXerj286PXcegiF1LkE7lL++qqMZW5jIQ=="
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "B95h0YLEL2oSnwF/XjqSWKnwKOy/01VWkNlsCeMTFJLLabflpGV26nK164eRs5GiaRSBGpOxQ3pKoSnnyZN5pg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "yxGIQd3BFK7F6S62/7RdZk3C/mfwyVxvh6ngd1VYMBmbJ1YZZA9+Ku6suylVtso0FjI0wbElpJ0d27CdsyLpBQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
+          "Microsoft.IdentityModel.Tokens": "6.35.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "3KlTJceQc3gnGIaHZ7UBZO26SHL1SHE4ddrmiwumFnId+CEHP+O8r386tZKaE6zlk5/mF8vifMBzHj9SaXN+mQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "IBErlVq5jOggAD69bg1t0pJcHaDbJbWNUZTPI96fkYWzwYbN6D9wRHMULLDd9dHsl7C2YsxXL31LMfPI1SWt8w==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Handles": "4.0.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "kWkKD203JJKxJeE74p8aF8y4Qc9r9WQx4C0cHzHPrY3fv/L/IhWnyCHaFJ3H1QPOH6A93whlQ2vG5nHlBDvzWQ==",
+        "dependencies": {
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "bQ0iYFOQI0nuTnt+NQADns6ucV4DUvMdwN6CbkB1yj8i7arTGiTN5eok1kQwdnnNWSDZfIUySQY+J3d5KjWn0g==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "I+y02iqkgmCAyfbqOmSDOgqdZQ5tTj80Akm5BPSS8EeB0VGWdy6X1KCoYe8Pk6pwDoAKZUOdLVxnTJcExiv5zw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit": "4.0.1",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Emit.Lightweight": "4.0.1",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw=="
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "JGkzeqgBsiZwKJZ1IxPNsDFZDhUvuEdX8L8BDC8N3KOj+6zMcNU28CNN59TpZE/VJYy9cP+5M+sbxtWJx3/xtw==",
+        "dependencies": {
+          "System.Text.Encodings.Web": "4.7.2",
+          "System.Text.Json": "4.6.0"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.0.12",
+        "contentHash": "tAgJM1xt3ytyMoW4qn4wIqgJYm7L7TShRZG4+Q4Qsi2PCcj96pXN7nRywS9KkB3p/xDUjc2HSwP9SROyPYDYKQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "JCKANJ0TI7kzoQzuwB/OoJANy1Lg338B6+JVacPl4TpUwi3cReg3nMLplMq2uqYfHFQpKIlHAUVAJlImZz/4ng==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "P2wqAj72fFjpP6wb9nSfDqNBMab+2ovzSDzUZK7MVIm54tBJEPr9jWfSjjoTpPwj1LeKcmX3vr0ttyjSSFM47g==",
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "Ov6dU8Bu15Bc7zuqttgHF12J5lwSWyTf1S+FJouUXVMSqImLZzYaQ+vRr1rQ0OZ0HqsrwWl4dsKHELckQkVpgA==",
+        "dependencies": {
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "sSzHHXueZ5Uh0OLpUQprhr+ZYJrLPA2Cmr4gn0wj9+FftNKXx8RIMKvO9qnjk2ebPYUjZ+F2ulGdPOsvj+MEjA==",
+        "dependencies": {
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "GYrtRsZcMuHF3sbmRHfMYpvxZoIN2bQGrYGerUiWLEkqdEUQZhH3TRSaC/oI4wO0II1RKBPlpIa1TOMxIcOOzQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Reflection": "4.1.0",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "4inTox4wTBaDhB7V3mPvp9XlCbeGYWVEM9/fXALd52vNEAVisc1BoVWQPuUuD0Ga//dNbA/WeMy9u9mzLxGTHQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "tsQ/ptQ3H5FYfON8lL4MxRk/8kFyE0A+tGPXmVP967cT/gzLHYxIejIYSxp4JmIeFHVP78g/F2FE1mUUTbDtrg==",
+        "dependencies": {
+          "System.Reflection": "4.1.0",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "TxwVeUNoTgUOdQ09gfTjvW411MF+w9MBYL7AtNVc+HtBCFlutPLhUCdZjNkjbhj3bNQWMdHboF0KIWEOjJssbA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Globalization": "4.0.11",
+          "System.Reflection": "4.1.0",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "JufQi0vPQ0xGnAczR13AUFglDyVYt4Kqnz1AZaiKZ5+GICq0/1MH/mO/eAJHt/mHW1zjKBJd7kV26SrxddAhiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Caching": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "E0e03kUp5X2k+UAoVl6efmI7uU7JRBWi5EIdlQ7cr0NpBGjHG4fWII35PgsBY9T4fJQ8E4QPsL0rKksU9gcL5A==",
+        "dependencies": {
+          "System.Configuration.ConfigurationManager": "6.0.0"
+        }
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "CUOHjTT/vgP0qGW22U4/hDlOqXmcPq5YicBaXdUR2UiUoLwBT+olO6we4DVbq57jeX5uXH2uerVZhf0qGj+sVQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "nCJvEKguXEvk2ymk1gqj625vVnlK3/xdGzx0vOKicQkoquaTBJTP13AIYkocSUwHCLNBwUbXTqTWGDxBTWpt7g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "16eu3kjHS633yYdkjwShDHZLRNMKVi/s0bY8ODiqJ2RfMhDMAwxZaUaWVnZ2P71kr/or+X9o/xFWtNqz8ivieQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Handles": "4.0.1"
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "hWPhJxc453RCa8Z29O91EmfGeZIHX1ZH2A8L6lYQVSaKzku2DfArSfMEb1/MYYzPQRJZeu0c9dmYeJKxW5Fgng==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "runtime.native.System": "4.0.0"
+        }
+      },
+      "System.Security.AccessControl": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "AUADIc0LIEQe7MzC+I0cl0rAT8RrTAKFHl53yHjEUzNVIaUlhFY11vc2ebiVJzVBuOzun6F7FBA+8KAbGTTedQ=="
+      },
+      "System.Security.Cryptography.Cng": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "jIMXsKn94T9JY7PvPq/tMfqa6GAaHpElRDpmG+SuL+D3+sTw2M8VhnibKnN8Tq+4JqbPJ/f+BwtLeDMEnzAvRg==",
+        "dependencies": {
+          "System.Formats.Asn1": "5.0.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "rp1gMNEZpvx9vP0JW0oHLxlf8oSiQgtno77Y4PLUBjSiDYoD77Y8uXHr1Ea5XG4/pIKhqAdxZ8v8OTUtqo9PeQ=="
+      },
+      "System.Security.Permissions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "T/uuc7AklkDoxmcJ7LGkyX1CcSviZuLCa4jg3PekfJ7SU0niF0IVTXwUiNVP9DSpzou2PpxJ+eNY2IfDM90ZCg==",
+        "dependencies": {
+          "System.Security.AccessControl": "6.0.0",
+          "System.Windows.Extensions": "6.0.0"
+        }
+      },
+      "System.Security.Principal.Windows": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "t0MGLukB5WAVU9bO3MGzvlGnyJPgUlcwerXn1kzBRjwLKixT96XV0Uza41W49gVd8zEMFu9vQEFlv0IOrytICA=="
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "BiIg+KWaSDOITze6jGQynxg64naAPtqGHBwDrLaCtixsa5bKiR8dpPOHA7ge3C0JJQizJE+sfkz1wV+BAKAYZw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.CodePages": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "ZFCILZuOvtKPauZ/j/swhvw68ZRi9ATCfvGbk1QfydmcXBkIWecWKn/250UH7rahZ5OoDBaiAudJtPvLwzw85A==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "yev/k9GHAEGx2Rg3/tU6MQh4HGBXJs70y7j1LaM1i/ER9po+6nnQ6RRqTJn1E7Xu0fbIFK80Nh5EoODxrbxwBQ=="
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "4.7.2",
+        "contentHash": "TcMd95wcrubm9nHvJEQs70rC0H/8omiSGGpU4FQ/ZA1URIqD4pjmFJh2Mfv1yH1eHgJDWTi2hMDXwTET+zOOyg=="
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "N+3xqIcg3VDKyjwwCGaZ9HawG9aC6cSDI+s7ROma310GQo8vilFZa86hqKppwTHleR/G0sfOzhvgnUxWCR/DrQ==",
+        "dependencies": {
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "k1S4Gc6IGwtHGT8188RSeGaX86Qw/wnrgNLshJvsdNUOPP9etMmo8S07c+UlOAx4K/xLuN9ivA1bD0LVurtIxQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.6.0",
+        "contentHash": "I5G6Y8jb0xRtGUC9Lahy7FUvlYlnGMMkbuKAQBy8Jb7Y6Yn8OlBEiUOY0PqZ0hy6Ua8poVA1ui1tAIiXNxGdsg=="
+      },
+      "System.Windows.Extensions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "IXoJOXIqc39AIe+CIR7koBtRGMiCt/LPM3lI+PELtDIy9XdyeSrwXFdWV9dzJ2Awl0paLWUaknLxFQ5HpHZUog==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
+        }
+      },
+      "ndjango.restframework": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "[2.*, )",
+          "Microsoft.AspNetCore.Mvc.Core": "[2.*, )",
+          "Microsoft.EntityFrameworkCore": "[8.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[8.*, )"
+        }
+      }
+    }
+  }
+}

--- a/scripts/start-sonarcloud.sh
+++ b/scripts/start-sonarcloud.sh
@@ -4,6 +4,7 @@ set -eu -o pipefail
 
 PROJECT_KEY="juntossomosmais_NDjango.RestFramework"
 ORGANIZATION="juntossomosmais"
+SONAR_SETTINGS_PATH="$(pwd)/sonar-project.xml"
 
 # You should start the scanner prior building your project and running your tests
 if [ -n "${PR_SOURCE_BRANCH:-}" ]; then
@@ -12,11 +13,10 @@ if [ -n "${PR_SOURCE_BRANCH:-}" ]; then
     /k:"$PROJECT_KEY" \
     /o:"$ORGANIZATION" \
     /d:sonar.host.url="https://sonarcloud.io" \
-    /d:sonar.cs.opencover.reportsPaths="**/*/coverage.opencover.xml" \
-    /d:sonar.cs.vstest.reportsPaths="**/*/*.trx" \
     /d:sonar.pullrequest.base="$PR_TARGET_BRANCH" \
     /d:sonar.pullrequest.branch="$PR_SOURCE_BRANCH" \
-    /d:sonar.pullrequest.key="$GITHUB_PR_NUMBER"
+    /d:sonar.pullrequest.key="$GITHUB_PR_NUMBER" \
+    /s:"$SONAR_SETTINGS_PATH"
 else
   dotnet sonarscanner begin \
     /d:sonar.login="$SONAR_TOKEN" \
@@ -24,9 +24,8 @@ else
     /k:"$PROJECT_KEY" \
     /o:"$ORGANIZATION" \
     /d:sonar.host.url="https://sonarcloud.io" \
-    /d:sonar.cs.opencover.reportsPaths="**/*/coverage.opencover.xml" \
-    /d:sonar.cs.vstest.reportsPaths="**/*/*.trx" \
-    /d:sonar.branch.name="$SOURCE_BRANCH_NAME"
+    /d:sonar.branch.name="$SOURCE_BRANCH_NAME" \
+    /s:"$SONAR_SETTINGS_PATH"
 fi
 
 # Now we can run our tests as usual

--- a/sonar-project.xml
+++ b/sonar-project.xml
@@ -1,9 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <SonarQubeAnalysisProperties xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                              xmlns="http://www.sonarsource.com/msbuild/integration/2015/1">
     <Property Name="sonar.host.url">http://localhost:9000</Property>
     <Property Name="sonar.cs.opencover.reportsPaths">**/*/coverage.opencover.xml</Property>
     <Property Name="sonar.cs.vstest.reportsPaths">**/*/*.trx</Property>
-    <Property Name="sonar.exclusions">**/Migrations/*.cs</Property>
+    <Property Name="sonar.exclusions">**/Migrations/*.cs,playwright/**,sample-project/**</Property>
+    <Property Name="sonar.coverage.exclusions">**/Migrations/*.cs,playwright/**,sample-project/**</Property>
 </SonarQubeAnalysisProperties>

--- a/src/NDjango.RestFramework/Base/ActionOptions.cs
+++ b/src/NDjango.RestFramework/Base/ActionOptions.cs
@@ -4,6 +4,7 @@ public class ActionOptions
 {
     public bool AllowPatch { get; set; } = true;
     public bool AllowPut { get; set; } = true;
+    public bool AllowDelete { get; set; } = true;
 
     /// <summary>
     /// Whether the <c>DELETE ?ids=</c> bulk-delete endpoint is exposed. Default <c>false</c> —

--- a/src/NDjango.RestFramework/Base/BaseController.cs
+++ b/src/NDjango.RestFramework/Base/BaseController.cs
@@ -382,6 +382,8 @@ namespace NDjango.RestFramework.Base
 
         /// <summary>
         /// Deletes an entity by its primary key. Returns 204 No Content on success.
+        /// Disable this endpoint via <see cref="ActionOptions.AllowDelete"/>; disabled hits
+        /// return <c>405 Method Not Allowed</c>.
         /// </summary>
         /// <param name="id">The primary key of the entity to delete.</param>
         /// <returns>
@@ -395,6 +397,9 @@ namespace NDjango.RestFramework.Base
             [FromRoute] TPrimaryKey id,
             CancellationToken cancellationToken = default)
         {
+            if (!_actionOptions.AllowDelete)
+                return StatusCode(StatusCodes.Status405MethodNotAllowed);
+
             var query = FilterQuery(GetQuerySet(), HttpContext.Request);
             var instance = await _serializer.GetObjectAsync(query, id, cancellationToken);
             if (instance is null)

--- a/src/NDjango.RestFramework/Base/IFieldConfigurableController.cs
+++ b/src/NDjango.RestFramework/Base/IFieldConfigurableController.cs
@@ -5,8 +5,8 @@ namespace NDjango.RestFramework.Base;
 
 internal interface IFieldConfigurableController
 {
-    string[] GetFieldsConfiguration();
-    string[] GetAllowedFieldsConfiguration();
-    Type GetDestinationType();
-    IReadOnlyList<string> GetMisnamedValidationHooks();
+    public string[] GetFieldsConfiguration();
+    public string[] GetAllowedFieldsConfiguration();
+    public Type GetDestinationType();
+    public IReadOnlyList<string> GetMisnamedValidationHooks();
 }

--- a/tests/NDjango.RestFramework.Test/Base/BaseControllerTests.cs
+++ b/tests/NDjango.RestFramework.Test/Base/BaseControllerTests.cs
@@ -93,6 +93,26 @@ public class BaseControllerTests
             var deleted = dbSet.AsNoTracking().FirstOrDefault(x => x.Id == customer2.Id);
             Assert.Null(deleted);
         }
+
+        [Fact]
+        public async Task Delete_WhenDeleteIsNotAllowedByActionOptions_ShouldReturnMethodNotAllowed()
+        {
+            // Arrange — IntAsIdEntitiesController is configured with AllowDelete = false
+            // so the single-resource DELETE returns 405 without touching the database.
+            var dbSet = Context.Set<IntAsIdEntity>();
+            var entity = new IntAsIdEntity() { Name = "abc" };
+            dbSet.Add(entity);
+            await Context.SaveChangesAsync();
+
+            // Act
+            var response = await Client.DeleteAsync($"api/IntAsIdEntities/{entity.Id}");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+
+            var stillExists = dbSet.AsNoTracking().Any(x => x.Id == entity.Id);
+            Assert.True(stillExists);
+        }
     }
 
     public class ValidateDestroy : IntegrationTests

--- a/tests/NDjango.RestFramework.Test/Support/Controllers.cs
+++ b/tests/NDjango.RestFramework.Test/Support/Controllers.cs
@@ -51,7 +51,7 @@ public class IntAsIdEntitiesController : BaseController<IntAsIdEntityDto, IntAsI
         : base(
             serializer,
             context,
-            new ActionOptions() { AllowPatch = false, AllowPut = false, AllowBulkDelete = false },
+            new ActionOptions() { AllowPatch = false, AllowPut = false, AllowDelete = false, AllowBulkDelete = false },
             logger)
     {
         AllowedFields =


### PR DESCRIPTION
## Summary

- **sample-project/** — minimal NDjango.RestFramework consumer with eight curated entities (Categories, Restaurants, RestaurantProfiles, Ingredients, MenuItems, Gifts, Tags, AuditLogs). Drives every documented library surface: built-in + custom filters, pagination/sorting, three `ActionOptions` shapes (`AllowBulkDelete=true`, `AllowDelete=false`, all-disabled), per-field `Validate{X}Async` + cross-field `ValidateAsync` overrides, `ValidateDestroyAsync` state predicate, custom `Query` with `.Include`, and a wide primitive type surface for OpenAPI schema coverage.
- **playwright/** — TypeScript e2e harness with 40 tests across six specs in ~9s on chromium: CRUD round-trips, OpenAPI contract assertions, pagination + sort + filters, validation hook positive/negative paths, AuditLogs verb gating, and nested-field projection through `.Include`.
- **.github/workflows/playwright.yml** — brings up the SQL Server compose service, builds `sample-project`, starts it on :8000, runs the suite. HTML report uploaded every run; sample log on failure.
- **`AllowDelete` gap closure** — `ActionOptions.AllowDelete` (default `true`) + inline-`405` guard on `BaseController.Delete`, matching the existing `Patch`/`Put`/`DeleteMany` pattern and `.claude/rules/action-options.md` contract. Includes a matching `BaseControllerTests.Delete` 405-when-disabled case.

## Test plan

- [x] `dotnet build sample-project/src/SampleProject.csproj` succeeds (0 errors).
- [x] Library test suite passes including the new `Delete_WhenDeleteIsNotAllowedByActionOptions_ShouldReturnMethodNotAllowed`.
- [x] `npx playwright test` green locally — 40/40 in ~9s on chromium.
- [ ] CI workflow green on this PR (`.github/workflows/playwright.yml`).
- [ ] Manual sanity check of `http://localhost:8000/swagger` showing the eight resources + the eight verbs per resource (inline-405 disabled actions still listed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)